### PR TITLE
Moved devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "Grunt",
     "Javascript"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/pattern-lab/patternlab-node.git"
+  },
   "author": "Brian Muenzenmeyer",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
This change was made, because patternlab should be seen as development
dependency.  Since this project relies on the following dependencies to
operate correctly, I have made the change to use "dependencies" instead
of "devDependencies".

The "devDependencies" will _not_ install when included in another
project.
