### PR TITLE
Abstracted template rendering; fixed issue with JSON files order in filesystem

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -112,7 +112,6 @@ var patternlab_engine = function(grunt){
 				var partialname = cleanSub + '-' + patternName.substring(patternName.indexOf('-') + 1);
 
 				patternlab.partials[partialname] = currentPattern.template;
-				hbs.registerPartial(partialname, currentPattern.template);
 
 				//done
 			}


### PR DESCRIPTION
Apologies, have been fighting the pull request system here.... which is why the rendering piece is in this request as well, it should be the same as the other.

There was an issue with JSON files as we explored handlebars, the .hbs extension put the template ahead of the json in the filesystem, causing errors.  We refactored the rendering process to just look for JSON and add it to the pattern's data along the way, and passing in global data if its null at render time.  This cleaned up some of the function duplication and big if statements from the previous example.

Happy to make any adjustments if needed, thanks for getting this project going!
