### PR TITLE
Forward slash

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -81,7 +81,7 @@ var patternlab_engine = function(){
 			}
 
 			//make a new Pattern Object
-			var flatPatternName = subdir.replace(/\\/g, '-') + '-' + patternName;
+			var flatPatternName = subdir.replace(/[\/\\]/g, '-') + '-' + patternName;
 			
 			flatPatternName = flatPatternName.replace(/\\/g, '-');
 			currentPattern = new of.oPattern(flatPatternName, subdir, filename, {});


### PR DESCRIPTION
Added support for forward slash in "FlatPatternName" regex pattern. On unix-systems the original regex didn't match.
