### PR TITLE
Changed host to hostname to avoid illegal url if a port is used

### DIFF
--- a/public/listeners/synclisteners.js
+++ b/public/listeners/synclisteners.js
@@ -18,7 +18,7 @@ var wsnConnected = false;
 var wsc;
 var wscConnected = false;
 var dataPrevious = 0;
-var host = (window.location.host != "") ? window.location.host : "127.0.0.1";
+var host = (window.location.host !== '') ? window.location.hostname : '127.0.0.1';
 
 // handle page updates from one browser to another
 function connectNavSync() {


### PR DESCRIPTION
Fixed pull request #58 
window.location.host contains port number localhost:9001
window.location.hostname is without port number

Sync Listeners creates a websocket url using the "host" variable. Therefore the "host" variable cannot contain a port number.
