### PR TITLE
adding multi-compiler functionality

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -176,13 +176,14 @@ var entity_encoder = new he();
         //extend pattern data links into link for pattern link shortcuts to work. we do this locally and globally
         pattern.data.link = extend({}, patternlab.data.link);
 
-        if(path.extname(pattern.templateEngine) !== 'mustache'){
+        if(pattern.templateEngine && (path.extname(pattern.templateEngine) !== 'mustache')){
+
           pattern.patternPartial = renderPatternAlt(pattern, patternlab.config);
         }else{
           pattern.patternPartial = renderPattern(pattern.template, pattern.data, patternlab.partials);
         }
       }else{ // Pass global patternlab data
-        if(path.extname(pattern.templateEngine) !== 'mustache'){
+        if(pattern.templateEngine && (path.extname(pattern.templateEngine) !== 'mustache')){
           pattern.patternPartial = renderPatternAlt(pattern, patternlab.config);
         }else{
           pattern.patternPartial = renderPattern(pattern.template, patternlab.data, patternlab.partials);

--- a/config.json
+++ b/config.json
@@ -32,5 +32,9 @@
       "homepage-emergency" : "inprogress"
   },
   "patternExportKeys": [],
-  "patternExportDirectory": "./pattern_exports/"
+  "patternExportDirectory": "./pattern_exports/",
+  "twig" : {
+    "base" : "./source/_patterns/",
+    "async" : false
+  }
  }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "engines": {
     "node": ">=0.1"
+  },
+  "dependencies": {
+    "twig": "^0.8.2"
   }
 }

--- a/source/_patternlab-files/index.mustache
+++ b/source/_patternlab-files/index.mustache
@@ -61,7 +61,7 @@
 		<div id="sg-code-markup">
 			<ul id="sg-code-tabs">
 				<li id="sg-code-title-html" class="sg-code-title-active">HTML</li>
-				<li id="sg-code-title-mustache">Mustache</li>
+				<li id="sg-code-title-mustache">Template</li>
 				<li id="sg-code-title-css" style="display: none;">CSS</li>
 			</ul>
 			<div class="clear">


### PR DESCRIPTION
Hi,

This is to add the ability to use alternative compiling engines with pattern lab. Specifically, I want to add twig, but made I tried to make my addition versatile enough so that other templating engines could be used. This should open up PL to use multiple template engines in a single PL instance if a developer needs that.

Please let me know what changes I could do. If this is acceptable, I can expand it to include more than just the patterns, but also the surrounding templates.

thanks,
Scott

p.s. my company will be using this in conjunction with our pattern library system:

http://github.com/pattern-library