### PR TITLE
more-flexible-mustache-partial-syntax

### DIFF
--- a/builder/parameter_hunter.js
+++ b/builder/parameter_hunter.js
@@ -21,12 +21,12 @@
 		function findparameters(pattern, patternlab){
 
 			//find the {{> template-name(*) }} within patterns
-			var matches = pattern.template.match(/{{>([ ]+)?([A-Za-z0-9-]+)(\()(.+)(\))([ ]+)?}}/g);
+			var matches = pattern.template.match(/{{>([ ]+)?([\w\-\.\/~]+)(\()(.+)(\))([ ]+)?}}/g);
 			if(matches !== null){
 				//compile this partial immeadiately, essentially consuming it.
 				matches.forEach(function(pMatch, index, matches){
 					//find the partial's name
-					var partialName = pMatch.match(/([a-z-]+)/ig)[0];
+					var partialName = pMatch.match(/([\w\-\.\/~]+)/g)[0];
 
 					if(patternlab.config.debug){
 						console.log('found patternParameters for ' + partialName);

--- a/builder/pattern_assembler.js
+++ b/builder/pattern_assembler.js
@@ -157,7 +157,7 @@
 
     function getpatternbykey(key, patternlab){
       for(var i = 0; i < patternlab.patterns.length; i++){
-        switch (key) {
+        switch(key) {
           case patternlab.patterns[i].key:
           case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName:
           case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName + '.mustache':

--- a/builder/pattern_assembler.js
+++ b/builder/pattern_assembler.js
@@ -157,7 +157,7 @@
 
     function getpatternbykey(key, patternlab){
       for(var i = 0; i < patternlab.patterns.length; i++){
-        switch(key) {
+        switch(key){
           case patternlab.patterns[i].key:
           case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName:
           case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName + '.mustache':

--- a/builder/pattern_assembler.js
+++ b/builder/pattern_assembler.js
@@ -25,7 +25,7 @@
 
     //find and return any {{> template-name }} within pattern
     function findPartials(pattern){
-      var matches = pattern.template.match(/{{>([ ])?([A-Za-z0-9-]+)(?:\:[A-Za-z0-9-]+)?(?:(| )\(.*)?([ ])?}}/g);
+      var matches = pattern.template.match(/{{>([ ])?([\w\-\.\/~]+)(?:\:[A-Za-z0-9-]+)?(?:(| )\(.*)?([ ])?}}/g);
       return matches;
     }
 
@@ -138,7 +138,7 @@
 
         //do something with the regular old partials
         for(var i = 0; i < foundPatternPartials.length; i++){
-          var partialKey = foundPatternPartials[i].replace(/{{>([ ])?([A-Za-z0-9-]+)(?:\:[A-Za-z0-9-]+)?(?:(| )\(.*)?([ ])?}}/g, '$2');
+          var partialKey = foundPatternPartials[i].replace(/{{>([ ])?([\w\-\.\/~]+)(?:\:[A-Za-z0-9-]+)?(?:(| )\(.*)?([ ])?}}/g, '$2');
           var partialPattern = getpatternbykey(partialKey, patternlab);
           currentPattern.extendedTemplate = currentPattern.extendedTemplate.replace(foundPatternPartials[i], partialPattern.extendedTemplate);
         }
@@ -157,8 +157,11 @@
 
     function getpatternbykey(key, patternlab){
       for(var i = 0; i < patternlab.patterns.length; i++){
-        if(patternlab.patterns[i].key === key){
-          return patternlab.patterns[i];
+        switch (key) {
+          case patternlab.patterns[i].key:
+          case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName:
+          case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName + '.mustache':
+            return patternlab.patterns[i];
         }
       }
       throw 'Could not find pattern with key ' + key;

--- a/test/parameter_hunter_tests.js
+++ b/test/parameter_hunter_tests.js
@@ -149,6 +149,150 @@
       test.done();
     },
 
-	};
+    'pattern hunter finds and extends templates with verbose partials' : function(test){
+
+      //setup current pattern from what we would have during execution
+      var currentPattern = {
+         "fileName": "01-sticky-comment",
+         "subdir": "02-organisms/02-comments",
+         "name": "02-organisms-02-comments-01-sticky-comment",
+         "data": null,
+         "jsonFileData": {},
+         "patternName": "sticky-comment",
+         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
+         "patternGroup": "organisms",
+         "patternSubGroup": "comments",
+         "flatPatternPath": "02-organisms-02-comments",
+         "key": "organisms-sticky-comment",
+         "template": "{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
+         "patternPartial": "",
+         "lineage": [
+         ],
+         "lineageIndex": [
+         ],
+         "lineageR": [
+         ],
+         "lineageRIndex": [
+         ],
+         "patternState": "",
+         "extendedTemplate": "{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
+      };
+      var patternlab = {
+        patterns: [
+          {
+             "fileName": "02-single-comment",
+             "subdir": "01-molecules/06-components",
+             "name": "01-molecules-06-components-02-single-comment",
+             "data": null,
+             "jsonFileData": {},
+             "patternName": "single-comment",
+             "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
+             "patternGroup": "molecules",
+             "patternSubGroup": "components",
+             "flatPatternPath": "01-molecules-06-components",
+             "key": "molecules-single-comment",
+             "template": "<p>{{description}}</p>",
+             "patternPartial": "",
+             "lineage": [
+             ],
+             "lineageIndex": [
+             ],
+             "lineageR": [
+             ],
+             "lineageRIndex": [
+             ],
+             "patternState": "",
+             "extendedTemplate": "<p>{{description}}</p>"
+          }
+        ],
+        config: {
+          debug: false
+        },
+        data: {
+          description: 'Not a quote from a smart man'
+        }
+      };
+
+      var parameter_hunter = new ph();
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
+
+      test.done();
+    },
+
+    'pattern hunter finds and extends templates with fully-pathed partials' : function(test){
+
+      //setup current pattern from what we would have during execution
+      var currentPattern = {
+         "fileName": "01-sticky-comment",
+         "subdir": "02-organisms/02-comments",
+         "name": "02-organisms-02-comments-01-sticky-comment",
+         "data": null,
+         "jsonFileData": {},
+         "patternName": "sticky-comment",
+         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
+         "patternGroup": "organisms",
+         "patternSubGroup": "comments",
+         "flatPatternPath": "02-organisms-02-comments",
+         "key": "organisms-sticky-comment",
+         "template": "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
+         "patternPartial": "",
+         "lineage": [
+         ],
+         "lineageIndex": [
+         ],
+         "lineageR": [
+         ],
+         "lineageRIndex": [
+         ],
+         "patternState": "",
+         "extendedTemplate": "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
+      };
+      var patternlab = {
+        patterns: [
+          {
+             "fileName": "02-single-comment",
+             "subdir": "01-molecules/06-components",
+             "name": "01-molecules-06-components-02-single-comment",
+             "data": null,
+             "jsonFileData": {},
+             "patternName": "single-comment",
+             "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
+             "patternGroup": "molecules",
+             "patternSubGroup": "components",
+             "flatPatternPath": "01-molecules-06-components",
+             "key": "molecules-single-comment",
+             "template": "<p>{{description}}</p>",
+             "patternPartial": "",
+             "lineage": [
+             ],
+             "lineageIndex": [
+             ],
+             "lineageR": [
+             ],
+             "lineageRIndex": [
+             ],
+             "patternState": "",
+             "extendedTemplate": "<p>{{description}}</p>"
+          }
+        ],
+        config: {
+          debug: false
+        },
+        data: {
+          description: 'Not a quote from a smart man'
+        }
+      };
+
+      var parameter_hunter = new ph();
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
+
+      test.done();
+    }
+
+  };
 
 }());

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -19,6 +19,23 @@
 			test.equals(results[1], '{{> molecules-single-comment(description: \'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.\') }}');
 
 			test.done();
+		},
+
+		'find_pattern_partials finds verbose partials' : function(test){
+
+			//setup current pattern from what we would have during execution
+			var currentPattern = {
+				"template": "<h1>{{> 01-molecules/06-components/03-comment-header.mustache }}</h1><div>{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}</div>",
+			};
+
+			var pattern_assembler = new pa();
+
+			var results = pattern_assembler.find_pattern_partials(currentPattern);
+			test.equals(results.length, 2);
+			test.equals(results[0], '{{> 01-molecules/06-components/03-comment-header.mustache }}');
+			test.equals(results[1], '{{> 01-molecules/06-components/02-single-comment(description: \'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.\') }}');
+
+			test.done();
 		}
 
 	};


### PR DESCRIPTION
Updating regexes and key options to allow for explicit paths to be used in Mustache partial tags. Referenced in issue #146 