### PR TITLE
Namespacing config and enable path configuration

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -25,7 +25,12 @@ var patternlab_engine = function () {
   patternlab = {};
 
   patternlab.package = fs.readJSONSync('./package.json');
-  patternlab.config = fs.readJSONSync('./config.json');
+  patternlab.config  = fs.readJSONSync('./config.json');
+
+  if (patternlab.config.patternlab != undefined) {
+    patternlab.config = patternlab.config.patternlab;
+  }
+
 
   function getVersion() {
     console.log(patternlab.package.version);

--- a/config.json
+++ b/config.json
@@ -1,38 +1,45 @@
- {
- 	"patterns" : {
- 		"source" : "./source/_patterns/",
- 		"public" : "./public/patterns/"
- 	},
-	"styleGuideExcludes": [
-		"templates",
-		"pages"
-	],
- 	"ignored-extensions" : ["scss", "DS_Store", "less"],
- 	"ignored-directories" : ["scss"],
- 	"debug": false,
- 	"ishControlsVisible": {
- 		"s": true,
- 		"m": true,
- 		"l": true,
- 		"full": true,
- 		"random": true,
- 		"disco": true,
- 		"hay": true,
- 		"mqs": true,
- 		"find": true,
- 		"views-all": true,
- 		"views-annotations": true,
- 		"views-code": true,
- 		"views-new": true,
- 		"tools-all": true,
- 		"tools-sync": true,
- 		"tools-shortcuts": true,
- 		"tools-docs": true
- 	},
-  "patternStates": {
-	  "homepage-emergency" : "inprogress"
-  },
-  "patternExportKeys": [],
-  "patternExportDirectory": "./pattern_exports/",
-  "baseurl" : ""
- }
+{
+    "patternlab": {
+		"files": "source/_patternlab-files",
+        "patterns" : {
+            "source" : "source/_patterns",
+            "public" : "public/patterns"
+        },
+        "data" : {
+            "source" : "source/_data",
+            "public" : "public/data"
+        },
+        "styleGuideExcludes": [
+            "templates",
+            "pages"
+        ],
+        "ignored-extensions" : ["scss", "DS_Store", "less"],
+        "ignored-directories" : ["scss"],
+        "debug": false,
+        "ishControlsVisible": {
+            "s": true,
+            "m": true,
+            "l": true,
+            "full": true,
+            "random": true,
+            "disco": true,
+            "hay": true,
+            "mqs": true,
+            "find": true,
+            "views-all": true,
+            "views-annotations": true,
+            "views-code": true,
+            "views-new": true,
+            "tools-all": true,
+            "tools-sync": true,
+            "tools-shortcuts": true,
+            "tools-docs": true
+        },
+        "patternStates": {
+            "homepage-emergency" : "inprogress"
+        },
+        "patternExportKeys": [],
+        "patternExportDirectory": "./pattern_exports/",
+        "baseurl" : ""
+    }
+}


### PR DESCRIPTION
This enables custom path configuration across the board for:

- patternlab files directory
- patterns directory
- data directory

Additionally, it will look to see if the config.json has a patternlab property and load the config from there, enabling simple namespacing while sharing the config with any additional application config you've built up around it for other tools.