### PR TITLE
Basics of being dependent and passing in config

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -25,7 +25,7 @@ var patternlab_engine = function (config) {
   patternlab = {};
 
   patternlab.package = fs.readJSONSync('./package.json');
-  patternlab.config = config || fs.readJSONSync('./config.json');
+  patternlab.config = config || fs.readJSONSync(path.resolve(__dirname, '../config.json'));
 
   var paths = patternlab.config.paths;
 

--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -8,7 +8,7 @@
  *
  */
 
-var patternlab_engine = function () {
+var patternlab_engine = function (config) {
   'use strict';
 
   var path = require('path'),
@@ -25,7 +25,7 @@ var patternlab_engine = function () {
   patternlab = {};
 
   patternlab.package = fs.readJSONSync('./package.json');
-  patternlab.config = fs.readJSONSync('./config.json');
+  patternlab.config = config || fs.readJSONSync('./config.json');
 
   var paths = patternlab.config.paths;
 

--- a/package.gulp.json
+++ b/package.gulp.json
@@ -2,21 +2,24 @@
   "name": "patternlab-node",
   "description": "Pattern Lab is a collection of tools to help you create atomic design systems. This is the node command line interface (CLI).",
   "version": "1.0.1",
-  "devDependencies": {
-    "browser-sync": "^2.10.0",
+  "main": "./builder/patternlab.js",
+  "dependencies": {
     "del": "^2.0.2",
     "diveSync": "^0.3.0",
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
+    "html-entities": "^1.2.0",
+    "mustache": "^2.2.0"
+  },
+  "devDependencies": {
+    "browser-sync": "^2.10.0",
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",
     "gulp-copy": "0.0.2",
     "gulp-header": "^1.7.1",
     "gulp-load": "^0.1.1",
     "gulp-nodeunit": "0.0.5",
-    "gulp-strip-banner": "0.0.2",
-    "html-entities": "^1.2.0",
-    "mustache": "^2.2.0"
+    "gulp-strip-banner": "0.0.2"
   },
   "keywords": [
     "Pattern Lab",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.1",
   "main": "./builder/patternlab.js",
   "dependencies": {
-    "bs-html-injector": "^3.0.0",
     "diveSync": "^0.3.0",
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
@@ -13,6 +12,7 @@
     "mustache": "^2.2.0"
   },
   "devDependencies": {
+    "bs-html-injector": "^3.0.0",
     "grunt": "~0.4.5",
     "grunt-browser-sync": "^2.2.0",
     "grunt-contrib-concat": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -2,20 +2,23 @@
   "name": "patternlab-node",
   "description": "Pattern Lab is a collection of tools to help you create atomic design systems. This is the node command line interface (CLI).",
   "version": "1.0.1",
-  "devDependencies": {
+  "main": "./builder/patternlab.js",
+  "dependencies": {
     "bs-html-injector": "^3.0.0",
     "diveSync": "^0.3.0",
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
+    "html-entities": "^1.2.0",
+    "matchdep": "^1.0.0",
+    "mustache": "^2.2.0"
+  },
+  "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-browser-sync": "^2.2.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-contrib-watch": "^0.6.1",
-    "html-entities": "^1.2.0",
-    "matchdep": "^1.0.0",
-    "mustache": "^2.2.0"
+    "grunt-contrib-watch": "^0.6.1"
   },
   "keywords": [
     "Pattern Lab",


### PR DESCRIPTION
OK, so here's the absolute basics of being able to `var pl = require('patternlab-node')(config);`. The big problem that remains is that most of the stuff that is ran from `builder/patternlab.js` (the `require`-ed file) is running from the working directory of `node_modules/patternlab-node/`, so this PR doesn't complete #221 but simply moves towards it and allows it to work if you know what you're doing. The way I'm getting around this (for now) is with this:

```js
var config = fs.readFileSync('./config--pattern-lab.json');
var pl = require('patternlab-node')(config);
// get directory
var plnDir = path.dirname(require.resolve('patternlab-node/package.json'));
// save place
var originCwd = process.cwd();
// change to pl directory
process.chdir(plnDir);
// build it
pl.build(true);
// come back
process.chdir(originCwd);
```

This PR also creates the distinction between dependencies and devDependencies – if this is a required dependency in other projects, only the dependencies get installed; otherwise when `npm install` is ran here, both get installed. 

I expect this PR to be easy to merge and should not disrupt other workflows or uses and hopefully we can build upon this approach by making `builder/patternlab.js` run in the correct working directory (I believe it's a distinction between `process.cwd()` and `__dirname`, but I'd need to look closer to really know).

🍻