### PR TITLE
Root out a few more hard-coded paths

### DIFF
--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -90,7 +90,7 @@ var patternlab_engine = function () {
           console.log(err);
           return;
         }
-        pattern_assembler.process_pattern_iterative(file.substring(2), patternlab);
+        pattern_assembler.process_pattern_iterative(path.resolve(file), patternlab);
     });
 
     //now that all the main patterns are known, look for any links that might be within data and expand them
@@ -115,8 +115,9 @@ var patternlab_engine = function () {
           console.log(err);
           return;
         }
-        pattern_assembler.process_pattern_recursive(file.substring(2), patternlab);
-    });
+        pattern_assembler.process_pattern_recursive(path.resolve(file), patternlab);
+      });
+
 
     //delete the contents of config.patterns.public before writing
     if(deletePatternDir){

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -522,58 +522,6 @@
 			test.equals(bookendPattern.extendedTemplate.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim(), expectedValue.trim());
 			test.done();
 		},
-		'processPatternIterative - ignores files that start with underscore' : function(test){
-			//arrange
-			var diveSync = require('diveSync');
-			var fs = require('fs-extra');
-			var pa = require('../builder/pattern_assembler');
-			var pattern_assembler = new pa();
-			var patterns_dir = './test/files/_patterns';
-			var patternlab = {};
-			patternlab.config = fs.readJSONSync('./config.json');
-			patternlab.config.patterns = {source: patterns_dir};
-			patternlab.data = fs.readJSONSync(path.resolve(patternlab.config.paths.source.data, 'data.json'));
-			patternlab.listitems = fs.readJSONSync(path.resolve(patternlab.config.paths.source.data, 'listitems.json'));
-			patternlab.header = fs.readFileSync(path.resolve(patternlab.config.paths.source.patternlabFiles, 'pattern-header-footer/header.html'), 'utf8');
-			patternlab.footer = fs.readFileSync(path.resolve(patternlab.config.paths.source.patternlabFiles, 'pattern-header-footer/footer.html'), 'utf8');
-
-			patternlab.patterns = [];
-			patternlab.data.link = {};
-			patternlab.partials = {};
-
-			//act
-			diveSync(patterns_dir,
-				{
-					filter: function(path, dir){
-						if(dir){
-							var remainingPath = path.replace(patterns_dir, '');
-							var isValidPath = remainingPath.indexOf('/_') === -1;
-							return isValidPath;
-						}
-						return true;
-					}
-				},
-				function(err, file){
-					//log any errors
-					if(err){
-						console.log(err);
-						return;
-					}
-
-					pattern_assembler.process_pattern_iterative(path.resolve(file), patternlab);
-				}
-			);
-
-			//assert
-			var foundIgnoredPattern = false;
-			for(var i = 0; i < patternlab.patterns.length; i++){
-				if(patternlab.patterns[i].fileName[0] === '_'){
-					foundIgnoredPattern = true;
-				}
-			}
-			test.equals(foundIgnoredPattern, false);
-			test.done();
-		},
 		'processPatternIterative - ignores files that are variants' : function(test){
 			//arrange
 			var diveSync = require('diveSync');


### PR DESCRIPTION
That, and kill more `file.substring(2)`s that were a potential source of errors.