### PR TITLE
bugfix: #171 pattern links inside base data object

### DIFF
--- a/builder/pattern_assembler.js
+++ b/builder/pattern_assembler.js
@@ -318,33 +318,36 @@
         return o;
     }
 
+    function parseDataLinksHelper (patternlab, obj, key) {
+      var linkRE, dataObjAsString, linkMatches, expandedLink;
+
+      linkRE = /link\.[A-z0-9-_]+/g
+      dataObjAsString = JSON.stringify(obj);
+      linkMatches = dataObjAsString.match(linkRE)
+
+      if(linkMatches) {
+        for (var i = 0; i < linkMatches.length; i++) {
+          expandedLink = patternlab.data.link[linkMatches[i].split('.')[1]];
+          if (expandedLink) {
+            if(patternlab.config.debug){
+              console.log('expanded data link from ' + linkMatches[i] + ' to ' + expandedLink + ' inside ' + key);
+            }
+            dataObjAsString = dataObjAsString.replace(linkMatches[i], expandedLink);
+          }
+        }
+      }
+      return JSON.parse(dataObjAsString)
+    }
     //look for pattern links included in data files.
     //these will be in the form of link.* WITHOUT {{}}, which would still be there from direct pattern inclusion
-    function parseDataLinks(patternlab){
+    function parseDataLinks(patternlab) {
+      //look for link.* such as link.pages-blog as a value
+
+      patternlab.data = parseDataLinksHelper(patternlab, patternlab.data, 'data.json')
 
       //loop through all patterns
-      for (var i = 0; i < patternlab.patterns.length; i++){
-        var pattern = patternlab.patterns[i];
-        //look for link.* such as link.pages-blog as a value
-        var linkRE = /link.[A-z0-9-_]+/g;
-        //convert to string for easier searching
-        var dataObjAsString = JSON.stringify(pattern.jsonFileData);
-        var linkMatches = dataObjAsString.match(linkRE);
-
-        //if no matches found, escape current loop iteration
-        if(linkMatches === null) { continue; }
-
-        for(var i = 0; i < linkMatches.length; i++){
-          //for each match, find the expanded link within the already constructed patternlab.data.link object
-          var expandedLink = patternlab.data.link[linkMatches[i].split('.')[1]];
-          if(patternlab.config.debug){
-            console.log('expanded data link from ' + linkMatches[i] + ' to ' + expandedLink + ' inside ' + pattern.key);
-          }
-          //replace value with expandedLink on the pattern
-          dataObjAsString = dataObjAsString.replace(linkMatches[i], expandedLink);
-        }
-        //write back to data on the pattern
-        pattern.jsonFileData = JSON.parse(dataObjAsString);
+      for (var i = 0; i < patternlab.patterns.length; i++) {
+        patternlab.patterns[i].jsonFileData = parseDataLinksHelper(patternlab, patternlab.patterns[i].jsonFileData, patternlab.patterns[i].key)
       }
     }
 

--- a/builder/patternlab.js
+++ b/builder/patternlab.js
@@ -91,10 +91,6 @@ var patternlab_engine = function () {
         pattern_assembler.process_pattern_iterative(file.substring(2), patternlab);
     });
 
-    //now that all the main patterns are known, look for any links that might be within data and expand them
-    //we need to do this before expanding patterns & partials into extendedTemplates, otherwise we could lose the data -> partial reference
-    pattern_assembler.parse_data_links(patternlab);
-
     //diveSync again to recursively include partials, filling out the
     //extendedTemplate property of the patternlab.patterns elements
     diveSync(patterns_dir, {
@@ -116,6 +112,10 @@ var patternlab_engine = function () {
 
         pattern_assembler.process_pattern_recursive(file.substring(2), patternlab);
     });
+
+    //now that all the main patterns are known, look for any links that might be within data and expand them
+    //we need to do this before expanding patterns & partials into extendedTemplates, otherwise we could lose the data -> partial reference
+    pattern_assembler.parse_data_links(patternlab);
 
     //delete the contents of config.patterns.public before writing
     if(deletePatternDir){

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -643,6 +643,11 @@
 			patternlab.data.link['twitter-dave'] = 'https://twitter.com/dmolsen';
 			patternlab.data.link['twitter-brian'] = 'https://twitter.com/bmuenzenmeyer';
 
+			patternlab.data.brad = { url: "link.twitter-brad" }
+			patternlab.data.dave = {	url: "link.twitter-dave" }
+			patternlab.data.brian = {	url: "link.twitter-brian" }
+
+
 			var pattern;
 			for(var i = 0; i < patternlab.patterns.length; i++){
 				if(patternlab.patterns[i].key === 'test-nav'){
@@ -661,6 +666,10 @@
 			test.equals(pattern.jsonFileData.brad.url, "https://twitter.com/brad_frost");
 			test.equals(pattern.jsonFileData.dave.url, "https://twitter.com/dmolsen");
 			test.equals(pattern.jsonFileData.brian.url, "https://twitter.com/bmuenzenmeyer");
+
+			test.equals(patternlab.data.brad.url, "https://twitter.com/brad_frost");
+			test.equals(patternlab.data.dave.url, "https://twitter.com/dmolsen");
+			test.equals(patternlab.data.brian.url, "https://twitter.com/bmuenzenmeyer");
 			test.done();
 		}
 	};


### PR DESCRIPTION
Hey, I would like to submit a minor bugfix to v1.0.0 regarding [*Added ability to specify link.* urls inside data objects*](https://github.com/pattern-lab/patternlab-node/issues/171)

This minor refactor allows for pattern links insde `_data.json` as well as pattern `*.json` objects

Also notice the RegExp has been updated to only match `link\.[A-z0-9-_]` to avoid matching `link123something` or `link*something`

Changed: target to dev branch