### PR TITLE
fixing regex for replace operation in findPartialKey_new

### DIFF
--- a/builder/pattern_engines/engine_mustache.js
+++ b/builder/pattern_engines/engine_mustache.js
@@ -75,7 +75,7 @@
     // given a pattern, and a partial string, tease out the "pattern key" and
     // return it.
     findPartialKey_new: function(partialString) {
-      var partialKey = partialString.replace(this.findPartialKeyRE, '$2');
+      var partialKey = partialString.replace(this.findPartialKeyRE, '$1');
       return partialKey;
     },
 


### PR DESCRIPTION
Addresses #250 (preliminary work)

Summary of changes:
Updating 2nd param for partialString.replace().
Old findPartialKeyRE:
  `/{{>([ ])?([\w\-\.\/~]+)(:[A-z-_|]+)?(?:\:[A-Za-z0-9-_]+)?(?:(| )\(.*)?([ ])?}}/g`
New findPartialKeyRE:
  `/{{>\s*([\w\-\.\/~]+)(\:[\w\-|]+)?(\:[\w\-]+)?(\s*\([^\)]*\))?\s*}}/g`

Since the capture group comprising ([\w\-\.\/~]+) used to be the 2nd capture group, but is now the 1st capture group, we need to update the 2nd param in partialString.replace() to '$1'.
