### PR TITLE
Better browsersync

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,10 @@ module.exports = function(grunt) {
 						ignoreInitial: true,
 						ignored: '*.html'
 					},
+                    snippetOptions: {
+                        // Ignore all HTML files within the templates folder
+                        blacklist: ['/index.html', '/']
+                    },
 					plugins: [
 						{
 							module: 'bs-html-injector',
@@ -108,7 +112,25 @@ module.exports = function(grunt) {
 								files: [path.resolve(paths().public.root + '/index.html'), path.resolve(paths().public.styleguide + '/styleguide.html')]
 							}
 						}
-					]
+					],
+                    notify: {
+                        styles: [
+                            'display: none',
+                            'padding: 15px',
+                            'font-family: sans-serif',
+                            'position: fixed',
+                            'font-size: 1em',
+                            'z-index: 9999',
+                            'bottom: 0px',
+                            'right: 0px',
+                            'border-top-left-radius: 5px',
+                            'background-color: #1B2032',
+                            'opacity: 0.4',
+                            'margin: 0',
+                            'color: white',
+                            'text-align: center'
+                        ]
+                    }
 				}
 			}
 		},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,10 +96,10 @@ gulp.task('cp:css', function(){
 // Styleguide Copy
 gulp.task('cp:styleguide', function(){
   return gulp.src(
-      [ '**/*'],
-      {cwd: path.resolve(paths().source.styleguide)} )
+      ['**/*'],
+      {cwd: path.resolve(paths().source.styleguide)})
       .pipe(gulp.dest(path.resolve(paths().public.styleguide)))
-      .pipe(browserSync.stream());;
+      .pipe(browserSync.stream());
 });
 
 //server and watch tasks
@@ -120,7 +120,7 @@ gulp.task('connect', ['lab'], function(){
       path.resolve(paths().source.data, '*.json'),
       path.resolve(paths().source.fonts + '/*'),
       path.resolve(paths().source.images + '/*'),
-      path.resolve(paths().source.data + '*.json'),
+      path.resolve(paths().source.data + '*.json')
     ],
     ['lab-pipe'],
     function () { browserSync.reload(); }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,11 +102,33 @@ gulp.task('cp:styleguide', function(){
       .pipe(browserSync.stream());
 });
 
-//server and watch tasks
-gulp.task('connect', ['lab'], function(){
+// server and watch tasks
+gulp.task('connect', ['lab'], function () {
   browserSync.init({
     server: {
       baseDir: path.resolve(paths().public.root)
+    },
+    snippetOptions: {
+      // Ignore all HTML files within the templates folder
+      blacklist: ['/index.html', '/']
+    },
+    notify: {
+      styles: [
+        'display: none',
+        'padding: 15px',
+        'font-family: sans-serif',
+        'position: fixed',
+        'font-size: 1em',
+        'z-index: 9999',
+        'bottom: 0px',
+        'right: 0px',
+        'border-top-left-radius: 5px',
+        'background-color: #1B2032',
+        'opacity: 0.4',
+        'margin: 0',
+        'color: white',
+        'text-align: center'
+      ]
     }
   });
   gulp.watch(path.resolve(paths().source.css, '**/*.css'), ['cp:css']);


### PR DESCRIPTION
Addresses #252, #159 

**Summary of changes:**
This blacklists the UI chrome to exempt it from browsersync's snippet injection, meaning that the only thing it's glommed onto is the iframe itself and the stuff inside it. This should hopefully eliminate most of the spooky behavior that comes from BS, and in my testing, makes CSS injection and auto-page-refresh (upon editing pattern HTML) work correctly under both grunt & gulp.

**Bonus:** this also moves the browsersync badge to the lower right and chills it out some -- a request from my team that I think would be welcome to others.