### PR TITLE
better regex for replacing single quotes

### DIFF
--- a/builder/parameter_hunter.js
+++ b/builder/parameter_hunter.js
@@ -40,11 +40,11 @@
 					var rightParen = pMatch.indexOf(')');
 					var paramString = '{' + pMatch.substring(leftParen + 1, rightParen) + '}';
 					//if param keys are wrapped in single quotes, replace with double quotes.
-					var paramStringWellFormed = paramString.replace(/(')([^']+)(')(\s*\:)/gm, '"$2"$4');
+					var paramStringWellFormed = paramString.replace(/(')([^']+)(')(\s*\:)/g, '"$2"$4');
 					//if params keys are not wrapped in any quotes, wrap in double quotes.
-					var paramStringWellFormed = paramStringWellFormed.replace(/([\{|,]\s*)([^\:\s]+)(\s*\:)/gm, '$1"$2"$3');
+					var paramStringWellFormed = paramStringWellFormed.replace(/([\{|,]\s*)([^\s"'\:]+)(\s*\:)/g, '$1"$2"$3');
 					//if param values are wrapped in single quotes, replace with double quotes.
-					var paramStringWellFormed = paramStringWellFormed.replace(/(\:\s*)(')([^']+)(')/gm, '$1"$3"');
+					var paramStringWellFormed = paramStringWellFormed.replace(/(\:\s*)(')([^']+)(')/g, '$1"$3"');
 
 					var paramData = {};
 					var globalData = {};

--- a/test/parameter_hunter_tests.js
+++ b/test/parameter_hunter_tests.js
@@ -1,109 +1,77 @@
 (function () {
-	"use strict";
+  "use strict";
 
-	var ph = require('../builder/parameter_hunter');
+  var ph = require('../builder/parameter_hunter');
 
-	exports['parameter_hunter'] = {
-		'pattern hunter finds and extends templates' : function(test){
+  //setup current pattern from what we would have during execution
+  function currentPatternClosure() {
+    return {
+      "fileName": "01-sticky-comment",
+      "subdir": "02-organisms/02-comments",
+      "name": "02-organisms-02-comments-01-sticky-comment",
+      "patternName": "sticky-comment",
+      "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
+      "patternGroup": "organisms",
+      "patternSubGroup": "comments",
+      "flatPatternPath": "02-organisms-02-comments",
+      "key": "organisms-sticky-comment",
+      "template": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
+      "extendedTemplate": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
+      "parameteredPartials": [
+        "{{> molecules-single-comment(description: 'We are all in the gutter, but some of us are looking at the stars.') }}",
+        "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
+      ]
+    };
+  }
 
-			//setup current pattern from what we would have during execution
-			var currentPattern = {
-         "fileName": "01-sticky-comment",
-         "subdir": "02-organisms/02-comments",
-         "name": "02-organisms-02-comments-01-sticky-comment",
-         "patternName": "sticky-comment",
-         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
-         "patternGroup": "organisms",
-         "patternSubGroup": "comments",
-         "flatPatternPath": "02-organisms-02-comments",
-         "key": "organisms-sticky-comment",
-         "template": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-         "extendedTemplate": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-				 "parameteredPartials": [
-						"{{> molecules-single-comment(description: 'We are all in the gutter, but some of us are looking at the stars.') }}",
-						"{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
-				 ]
-			};
-			var patternlab = {
-				patterns: [
-                  {
-                     "fileName": "02-single-comment",
-                     "subdir": "01-molecules/06-components",
-                     "name": "01-molecules-06-components-02-single-comment",
-                     "patternName": "single-comment",
-                     "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
-                     "patternGroup": "molecules",
-                     "patternSubGroup": "components",
-                     "flatPatternPath": "01-molecules-06-components",
-                     "key": "molecules-single-comment",
-                     "template": "<p>{{description}}</p>",
-                     "extendedTemplate": "<p>{{description}}</p>"
-                  }
-				],
-        config: {
-          debug: false
-        },
-        data: {
-          description: 'Not a quote from a smart man'
-        },
-        partials: {},
-			};
+  function patternlabClosure() {
+    return {
+      patterns: [
+        {
+          "fileName": "02-single-comment",
+          "subdir": "01-molecules/06-components",
+          "name": "01-molecules-06-components-02-single-comment",
+          "patternName": "single-comment",
+          "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
+          "patternGroup": "molecules",
+          "patternSubGroup": "components",
+          "flatPatternPath": "01-molecules-06-components",
+          "key": "molecules-single-comment",
+          "template": "<p>{{description}}</p>",
+          "extendedTemplate": "<p>{{description}}</p>"
+        }
+      ],
+      config: {
+        debug: false
+      },
+      data: {
+        description: 'Not a quote from a smart man'
+      },
+      partials: {}
+    }
+  };
 
-			var parameter_hunter = new ph();
+  exports['parameter_hunter'] = {
+    'parameter hunter finds and extends templates' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
 
       parameter_hunter.find_parameters(currentPattern, patternlab);
       test.equals(currentPattern.extendedTemplate, '<p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
 
-			test.done();
-		},
+      test.done();
+    },
 
-    'pattern hunter finds and extends templates with mixed parameter and global data' : function(test){
-
-      //setup current pattern from what we would have during execution
-      var currentPattern = {
-         "fileName": "01-sticky-comment",
-         "subdir": "02-organisms/02-comments",
-         "name": "02-organisms-02-comments-01-sticky-comment",
-         "patternName": "sticky-comment",
-         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
-         "patternGroup": "organisms",
-         "patternSubGroup": "comments",
-         "flatPatternPath": "02-organisms-02-comments",
-         "key": "organisms-sticky-comment",
-         "template": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-         "extendedTemplate": "{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-				 "parameteredPartials": [
-						"{{> molecules-single-comment(description: 'We are all in the gutter, but some of us are looking at the stars.') }}",
-						"{{> molecules-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
-				 ]
-      };
-      var patternlab = {
-        partials: {},
-        patterns: [
-          {
-             "fileName": "02-single-comment",
-             "subdir": "01-molecules/06-components",
-             "name": "01-molecules-06-components-02-single-comment",
-             "patternName": "single-comment",
-             "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
-             "patternGroup": "molecules",
-             "patternSubGroup": "components",
-             "flatPatternPath": "01-molecules-06-components",
-             "key": "molecules-single-comment",
-             "template": "<h1>{{foo}}</h1><p>{{description}}</p>",
-             "extendedTemplate": "<h1>{{foo}}</h1><p>{{description}}</p>"
-          }
-        ],
-        config: {
-          debug: false
-        },
-        data: {
-          foo: 'Bar',
-          description: 'Baz'
-        }
-      };
-
+    'parameter hunter finds and extends templates with mixed parameter and global data' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
       var parameter_hunter = new ph();
+
+      patternlab.patterns[0].template = "<h1>{{foo}}</h1><p>{{description}}</p>";
+      patternlab.patterns[0].extendedTemplate = patternlab.patterns[0].template;
+      patternlab.data.foo = 'Bar';
+      patternlab.data.description = 'Baz';
 
       parameter_hunter.find_parameters(currentPattern, patternlab);
       test.equals(currentPattern.extendedTemplate, '<h1>Bar</h1><p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
@@ -111,52 +79,15 @@
       test.done();
     },
 
-    'pattern hunter finds and extends templates with verbose partials' : function(test){
-
-      //setup current pattern from what we would have during execution
-      var currentPattern = {
-         "fileName": "01-sticky-comment",
-         "subdir": "02-organisms/02-comments",
-         "name": "02-organisms-02-comments-01-sticky-comment",
-         "patternName": "sticky-comment",
-         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
-         "patternGroup": "organisms",
-         "patternSubGroup": "comments",
-         "flatPatternPath": "02-organisms-02-comments",
-         "key": "organisms-sticky-comment",
-         "template": "{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-         "extendedTemplate": "{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-				 "parameteredPartials": [
-						"{{> 01-molecules/06-components/02-single-comment(description: 'We are all in the gutter, but some of us are looking at the stars.') }}",
-						"{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
-				 ]
-      };
-      var patternlab = {
-          partials: {},
-          patterns: [
-          {
-             "fileName": "02-single-comment",
-             "subdir": "01-molecules/06-components",
-             "name": "01-molecules-06-components-02-single-comment",
-             "patternName": "single-comment",
-             "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
-             "patternGroup": "molecules",
-             "patternSubGroup": "components",
-             "flatPatternPath": "01-molecules-06-components",
-             "key": "molecules-single-comment",
-             "template": "<p>{{description}}</p>",
-             "extendedTemplate": "<p>{{description}}</p>"
-          }
-        ],
-        config: {
-          debug: false
-        },
-        data: {
-          description: 'Not a quote from a smart man'
-        }
-      };
-
+    'parameter hunter finds and extends templates with verbose partials' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
       var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> 01-molecules/06-components/02-single-comment(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = "{{> 01-molecules/06-components/02-single-comment(description: 'We are all in the gutter, but some of us are looking at the stars.') }}";
+      currentPattern.parameteredPartials[1] = currentPattern.template;
 
       parameter_hunter.find_parameters(currentPattern, patternlab);
       test.equals(currentPattern.extendedTemplate, '<p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
@@ -164,59 +95,143 @@
       test.done();
     },
 
-    'pattern hunter finds and extends templates with fully-pathed partials' : function(test){
-
-      //setup current pattern from what we would have during execution
-      var currentPattern = {
-         "fileName": "01-sticky-comment",
-         "subdir": "02-organisms/02-comments",
-         "name": "02-organisms-02-comments-01-sticky-comment",
-         "patternName": "sticky-comment",
-         "patternLink": "02-organisms-02-comments-01-sticky-comment/02-organisms-02-comments-01-sticky-comment.html",
-         "patternGroup": "organisms",
-         "patternSubGroup": "comments",
-         "flatPatternPath": "02-organisms-02-comments",
-         "key": "organisms-sticky-comment",
-         "template": "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-         "extendedTemplate": "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}",
-				 "parameteredPartials": [
-						"{{> 01-molecules/06-components/02-single-comment.mustache(description: 'We are all in the gutter, but some of us are looking at the stars.') }}",
-						"{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}"
-				 ]
-      };
-      var patternlab = {
-          partials: {},
-          patterns: [
-          {
-             "fileName": "02-single-comment",
-             "subdir": "01-molecules/06-components",
-             "name": "01-molecules-06-components-02-single-comment",
-             "patternName": "single-comment",
-             "patternLink": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html",
-             "patternGroup": "molecules",
-             "patternSubGroup": "components",
-             "flatPatternPath": "01-molecules-06-components",
-             "key": "molecules-single-comment",
-             "template": "<p>{{description}}</p>",
-             "extendedTemplate": "<p>{{description}}</p>"
-          }
-        ],
-        config: {
-          debug: false
-        },
-        data: {
-          description: 'Not a quote from a smart man'
-        }
-      };
-
+    'parameter hunter finds and extends templates with fully-pathed partials' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
       var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'A life is like a garden. Perfect moments can be had, but not preserved, except in memory.') }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = "{{> 01-molecules/06-components/02-single-comment.mustache(description: 'We are all in the gutter, but some of us are looking at the stars.') }}";
+      currentPattern.parameteredPartials[1] = currentPattern.template;
 
       parameter_hunter.find_parameters(currentPattern, patternlab);
       test.equals(currentPattern.extendedTemplate, '<p>A life is like a garden. Perfect moments can be had, but not preserved, except in memory.</p>');
 
       test.done();
-    }
+    },
 
+    //previous tests were for unquoted parameter keys and single-quoted values.
+    //test other quoting options.
+    'parameter hunter parses parameters with unquoted keys and unquoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment(description: true) }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with unquoted keys and double-quoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment(description: \"true\") }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with single-quoted keys and unquoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment('description': true) }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with single-quoted keys and single-quoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment('description': 'true') }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with single-quoted keys and double-quoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment('description': \"true\") }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with double-unquoted keys and unquoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment(\"description\": true) }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with double-quoted keys and single-quoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment(\"description\": 'true') }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    },
+
+    'parameter hunter parses parameters with double-quoted keys and double-quoted values' : function(test){
+      var currentPattern = currentPatternClosure();
+      var patternlab = patternlabClosure();
+      var parameter_hunter = new ph();
+
+      currentPattern.template = "{{> molecules-single-comment(\"description\": \"true\") }}";
+      currentPattern.extendedTemplate = currentPattern.template;
+      currentPattern.parameteredPartials[0] = currentPattern.template;
+
+      parameter_hunter.find_parameters(currentPattern, patternlab);
+      test.equals(currentPattern.extendedTemplate, '<p>true</p>');
+
+      test.done();
+    }
   };
 
 }());


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #250 (preliminary work)

Summary of changes:
@bmuenzenmeyer Tightening up the regex for JSON parsing parameter submission. Needed better regex for single-quote wrapped keys. Also, don't need the m flag.
