### PR TITLE
Fix double BrowserSync on whole-UI refresh after selecting pattern

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
 					},
                     snippetOptions: {
                         // Ignore all HTML files within the templates folder
-                        blacklist: ['/index.html', '/', '/?p=*']
+                        blacklist: ['/index.html', '/', '/?*']
                     },
 					plugins: [
 						{

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
 					},
                     snippetOptions: {
                         // Ignore all HTML files within the templates folder
-                        blacklist: ['/index.html', '/']
+                        blacklist: ['/index.html', '/', '/?p=*']
                     },
 					plugins: [
 						{

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ gulp.task('connect', ['lab'], function () {
     },
     snippetOptions: {
       // Ignore all HTML files within the templates folder
-      blacklist: ['/index.html', '/']
+      blacklist: ['/index.html', '/', '/?p=*']
     },
     notify: {
       styles: [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ gulp.task('connect', ['lab'], function () {
     },
     snippetOptions: {
       // Ignore all HTML files within the templates folder
-      blacklist: ['/index.html', '/', '/?p=*']
+      blacklist: ['/index.html', '/', '/?*']
     },
     notify: {
       styles: [


### PR DESCRIPTION
Summary of changes:

Add glob in the BrowserSync blacklist to match ?p= pattern URLs on the main UI chrome so BS won't load on both in the case where you select a specific pattern and then refresh the whole page.

We were having mysterious issues with a double BS badge appearing unpredictably, and it turns out this was the issue.

Would you prefer I create an issue and then refer to it in cases like this, or just do the PR?

EDIT: addresses #273 