### PR TITLE
fix documentation links in the header bar

### DIFF
--- a/core/templates/partials/ishControls.mustache
+++ b/core/templates/partials/ishControls.mustache
@@ -52,8 +52,8 @@
 					<a href="#" class="sg-acc-handle sg-tools-toggle sg-icon sg-icon-cog" id="sg-tools-toggle" title="Tools"><span class="is-vishidden">Tools</span></a>
 					<ul class="sg-acc-panel sg-right sg-checklist">
 						{{# ishControlsVisible.tools-sync }}<li><a href="http://localhost:3001" target="_blank" id="syncButton" class="sg-checkbox sg-auto-reload" data-state="off">BrowserSync UI</a></li>{{/ ishControlsVisible.tools-sync }}
-						{{# ishControlsVisible.tools-shortcuts }}<li><a href="http://pattern-lab.info/docs/advanced-keyboard-shortcuts.html" class="sg-icon-keyboard" target="_blank">Keyboard Shortcuts</a>{{/ ishControlsVisible.tools-shortcuts }}
-						{{# ishControlsVisible.tools-docs }}<li><a href="http://pattern-lab.info/docs/" class="sg-icon-file" target="_blank">Pattern Lab Docs</a>{{/ ishControlsVisible.tools-docs }}
+						{{# ishControlsVisible.tools-shortcuts }}<li><a href="http://patternlab.io/docs/advanced-keyboard-shortcuts.html" class="sg-icon-keyboard" target="_blank">Keyboard Shortcuts</a>{{/ ishControlsVisible.tools-shortcuts }}
+						{{# ishControlsVisible.tools-docs }}<li><a href="http://patternlab.io/docs/" class="sg-icon-file" target="_blank">Pattern Lab Docs</a>{{/ ishControlsVisible.tools-docs }}
 					</ul>
 				</li>
 				{{/ ishControlsVisible.tools-all }}


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Summary of changes:
- links in ishControls were pointing to pattern-lab.info, which is now just a Media Temple parking page
- now pointing to patternlab.io