### PR TITLE
Dev 2.0 full pattern objects passed to engine render

### DIFF
--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -1,6 +1,6 @@
-/* 
- * patternlab-node - v1.2.0 - 2016 
- * 
+/*
+ * patternlab-node - v1.2.0 - 2016
+ *
  * Brian Muenzenmeyer, and the web community.
  * Licensed under the MIT license.
  *
@@ -49,7 +49,7 @@ oPattern.prototype = {
   // render method on oPatterns; this acts as a proxy for the PatternEngine's
   // render function
   render: function (data, partials) {
-    return this.engine.renderPattern(this.extendedTemplate, data || this.jsonFileData, partials);
+    return this.engine.renderPattern(this, data || this.jsonFileData, partials);
   },
 
   registerPartial: function () {

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -120,9 +120,9 @@ var pattern_assembler = function () {
       return pattern.render(data, partials);
     } else {
       // otherwise, assume it's a plain mustache template string, and we
-      // therefore just need to create a container pattern to be able to render
+      // therefore just need to create a dummpy pattern to be able to render
       // it
-      var dummyPattern = of.oPattern.create({extendedTemplate: pattern});
+      var dummyPattern = of.oPattern.createEmpty({extendedTemplate: pattern});
       return patternEngines.mustache.renderPattern(dummyPattern, data, partials);
     }
   }

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -112,15 +112,18 @@ var pattern_assembler = function () {
     }
   }
 
+  // Render a pattern on request. Long-term, this should probably go away.
   function renderPattern(pattern, data, partials) {
     // if we've been passed a full oPattern, it knows what kind of template it
     // is, and how to render itself, so we just call its render method
     if (pattern instanceof of.oPattern) {
       return pattern.render(data, partials);
     } else {
-      // otherwise, assume it's a plain mustache template string and act
-      // accordingly
-      return patternEngines.mustache.renderPattern(pattern, data, partials);
+      // otherwise, assume it's a plain mustache template string, and we
+      // therefore just need to create a container pattern to be able to render
+      // it
+      var dummyPattern = of.oPattern.create({extendedTemplate: pattern});
+      return patternEngines.mustache.renderPattern(dummyPattern, data, partials);
     }
   }
 

--- a/core/lib/pattern_engines/engine_handlebars.js
+++ b/core/lib/pattern_engines/engine_handlebars.js
@@ -36,11 +36,11 @@ var engine_handlebars = {
   findListItemsRE: /({{#( )?)(list(I|i)tems.)(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)( )?}}/g,
 
   // render it
-  renderPattern: function renderPattern(template, data, partials) {
+  renderPattern: function renderPattern(pattern, data, partials) {
     if (partials) {
       Handlebars.registerPartial(partials);
     }
-    var compiled = Handlebars.compile(template);
+    var compiled = Handlebars.compile(pattern.extendedTemplate);
     return compiled(data);
   },
 

--- a/core/lib/pattern_engines/engine_mustache.js
+++ b/core/lib/pattern_engines/engine_mustache.js
@@ -39,11 +39,11 @@ var engine_mustache = {
   findPartialKeyRE: utilMustache.partialKeyRE,
 
   // render it
-  renderPattern: function renderPattern(template, data, partials) {
+  renderPattern: function renderPattern(pattern, data, partials) {
     if (partials) {
-      return Mustache.render(template, data, partials);
+      return Mustache.render(pattern.extendedTemplate, data, partials);
     }
-    return Mustache.render(template, data);
+    return Mustache.render(pattern.extendedTemplate, data);
   },
 
   /**

--- a/core/lib/pattern_engines/engine_twig.js
+++ b/core/lib/pattern_engines/engine_twig.js
@@ -37,9 +37,9 @@ var engine_twig = {
   findListItemsRE: /({{#( )?)(list(I|i)tems.)(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)( )?}}/g, // TODO
 
   // render it
-  renderPattern: function renderPattern(template, data) {
+  renderPattern: function renderPattern(pattern, data) {
     var result = twig({
-      data: template
+      data: pattern.extendedTemplate
     }).render(data);
 
     return result;

--- a/core/lib/pattern_engines/engine_underscore.js
+++ b/core/lib/pattern_engines/engine_underscore.js
@@ -51,8 +51,8 @@
     findListItemsRE: /({{#( )?)(list(I|i)tems.)(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)( )?}}/g,
 
     // render it
-    renderPattern: function renderPattern(template, data, partials) {
-      var compiled = _.template(template);
+    renderPattern: function renderPattern(pattern, data, partials) {
+      var compiled = _.template(pattern.extendedTemplate);
       var renderedHTML;
 
       // This try-catch is necessary because references to undefined variables
@@ -65,7 +65,7 @@
           _partials: partials
         }));
       } catch (e) {
-        var errorMessage = "WARNING: the underscore template " + template.fileName + " threw an exception; it probably just tried to reference an undefined variable. Is this pattern maybe missing a .json file?";
+        var errorMessage = "WARNING: the underscore template " + pattern.fileName + " threw an exception; it probably just tried to reference an undefined variable. Is this pattern maybe missing a .json file?";
         console.log(errorMessage, e);
         renderedHTML = "<h1>Error in underscore template</h1>" + errorMessage;
       }


### PR DESCRIPTION
Hey, Brian -- this is an architectural change that requires engines' `renderPattern()` methods to be passed a full oPattern rather than just the extendedTemplate string. This came about because I wanted be able to print useful error messages in underscore templates, but realized that when an engine actually gets around to render time, it doesn't know what the file name of the pattern being rendered is, the pattern name, or really anything else about it except the template string itself.

So the solution proposed here is just to pass the full pattern object into renderPattern() methods. As before, the `renderPattern()` function in `pattern_assembler.js` is used as a compatibility shim so the UI can still render its "plain" mustache templates. Have a look at that to see if that feels too hackish to you.

Bonus: I think this may also address an access-to-data problem that @sghoweri had when implementing Twig support.

The number of failing unit tests is the same as currently for the `dev-2.0-core` branch.