### PR TITLE
Annotations v1

### DIFF
--- a/core/lib/annotation_exporter.js
+++ b/core/lib/annotation_exporter.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var annotations_exporter = function (pl) {
+  var path = require('path'),
+    fs = require('fs-extra'),
+    JSON5 = require('json5'),
+    paths = pl.config.paths;
+
+  // HELPER FUNCTIONS
+  function parseAnnotationsJS() {
+    //attempt to read the file
+    try {
+      var oldAnnotations = fs.readFileSync(path.resolve(paths.source.annotations, 'annotations.js'), 'utf8');
+    } catch (ex) {
+      console.log(ex, 'This may be expected.');
+    }
+
+    //parse as JSON by removing the old wrapping js syntax. comments and the trailing semi-colon
+    oldAnnotations = oldAnnotations.replace('var comments = ', '');
+    try {
+      var oldAnnotationsJSON = JSON5.parse(oldAnnotations.trim().slice(0, -1));
+    } catch (ex) {
+      console.log('There was an error parsing JSON for ' + paths.source.annotations + 'annotations.js');
+      console.log(ex);
+    }
+    return oldAnnotationsJSON;
+  }
+
+  function gatherAnnotations() {
+    //todo: merge markdown too https://github.com/pattern-lab/patternlab-php-core/blob/c2c4bc6a8bda2b2f9c08b197669ebc94c025e7c6/src/PatternLab/Annotations.php
+    return parseAnnotationsJS();
+  }
+
+  return {
+    gather: function () {
+      return gatherAnnotations();
+    }
+  };
+
+};
+
+module.exports = annotations_exporter;

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -351,6 +351,8 @@ function sortPatterns(patternsArray) {
 function buildFrontEnd(patternlab) {
   var mh = require('./media_hunter');
   var media_hunter = new mh();
+  var ae = require('./annotation_exporter');
+  var annotation_exporter = new ae(patternlab);
   var styleguidePatterns = [];
   var paths = patternlab.config.paths;
 
@@ -439,8 +441,8 @@ function buildFrontEnd(patternlab) {
   fs.outputFileSync(path.resolve(paths.public.data, 'patternlab-data.js'), output);
 
   //annotations
-  //todo: build this from _source/annotations/ https://github.com/pattern-lab/patternlab-php-core/blob/c2c4bc6a8bda2b2f9c08b197669ebc94c025e7c6/src/PatternLab/Annotations.php
-  var annotations = 'var comments = [];' + eol;
+  var annotationsJSON = annotation_exporter.gather();
+  var annotations = 'var comments = ' + JSON.stringify(annotationsJSON);
   fs.outputFileSync(path.resolve(paths.public.annotations, 'annotations.js'), annotations);
 
 }


### PR DESCRIPTION
Addresses part of https://github.com/pattern-lab/edition-node-gulp/issues/12

Summary of changes:
Adds back in support for the current style of annotations, reading in `annotations.js`, parsing it as JSON, and outputting to the new location. 
Work remaining includes understanding how to use a markdown file instead.