### PR TITLE
336 remove hardcoded path

### DIFF
--- a/core/lib/annotation_exporter.js
+++ b/core/lib/annotation_exporter.js
@@ -51,7 +51,7 @@ var annotations_exporter = function (pl) {
 
       //for each annotation process the yaml frontmatter and markdown
       var annotationSnippet = annotationsYAML[i];
-      var annotationsRE = /---\n{1}([\s\S]*)---\n{1}([\s\S]*)+/gm;
+      var annotationsRE = /---\r?\n{1}([\s\S]*)---\r?\n{1}([\s\S]*)+/gm;
       var chunks = annotationsRE.exec(annotationSnippet);
       if (chunks && chunks[1] && chunks[2]) {
 

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -355,7 +355,7 @@ function buildFrontEnd(patternlab) {
   patternlab.patterns = sortPatterns(patternlab.patterns);
 
   //find mediaQueries
-  media_hunter.find_media_queries('./source/css', patternlab);
+  media_hunter.find_media_queries(path.resolve(paths.source.css), patternlab);
 
   // check if patterns are excluded, if not add them to styleguidePatterns
   styleguidePatterns = assembleStyleguidePatterns(patternlab);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "handlebars": "^4.0.5",
     "html-entities": "^1.2.0",
     "json5": "^0.5.0",
-    "lodash": "~4.13.0",
+    "lodash": "~4.13.1",
     "markdown-it": "^6.0.1",
     "mustache": "^2.2.0",
     "twig": "^0.9.5",


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses https://github.com/pattern-lab/patternlab-node/issues/336

Summary of changes:

- uses paths construct to find css location
- passes unit tests.
- could not test in edition-node-gulp yet. will keep an eye on this feature.
