### PR TITLE
Make the engine unit tests chill out if their engines aren't installed

### DIFF
--- a/test/engine_handlebars_tests.js
+++ b/test/engine_handlebars_tests.js
@@ -1,21 +1,10 @@
 "use strict";
 
-// don't run these tests unless handlebars is installed
-try { var handlebars = require('handlebars'); }
-catch (err) { return; }
-
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
 var testPatternsPath = path.resolve(__dirname, 'files', '_handlebars-test-patterns');
 var eol = require('os').EOL;
-
-try {
-  require('handlebars');
-} catch (err) {
-  console.log('handlebars renderer not installed; skipping tests');
-  return;
-}
 
 // fake pattern lab constructor:
 // sets up a fake patternlab object, which is needed by the pattern processing
@@ -194,3 +183,11 @@ exports['engine_handlebars'] = {
     ]);
   }
 };
+
+
+// don't run these tests unless handlebars is installed
+var engineLoader = require('../core/lib/pattern_engines');
+if (!engineLoader.handlebars) {
+  console.log("Handlebars engine not installed, skipping tests.");
+  delete exports.engine_handlebars;
+}

--- a/test/engine_twig_tests.js
+++ b/test/engine_twig_tests.js
@@ -1,22 +1,10 @@
 "use strict";
 /*eslint-disable dot-notation*/
 
-// don't run these tests unless twig is installed
-try { var twig = require('twig'); }
-catch (err) { return; }
-
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
-var testPatternsPath = path.resolve(__dirname, 'files', '_twig-test-patterns');
 var eol = require('os').EOL;
-
-try {
-  require('twig');
-} catch (err) {
-  console.log('twig renderer not installed; skipping tests');
-  return;
-}
 
 // fake pattern lab constructor:
 // sets up a fake patternlab object, which is needed by the pattern processing
@@ -193,3 +181,11 @@ exports['engine_twig'] = {
     ]);
   }
 };
+
+
+// don't run these tests unless twig is installed
+var engineLoader = require('../core/lib/pattern_engines');
+if (!engineLoader.twig) {
+  console.log("Twig engine not installed, skipping tests.");
+  delete exports.engine_twig;
+}

--- a/test/engine_underscore_tests.js
+++ b/test/engine_underscore_tests.js
@@ -1,85 +1,85 @@
-(function () {
-  "use strict";
+"use strict";
 
-  var path = require('path');
-  var pa = require('../core/lib/pattern_assembler');
-  var testPatternsPath = path.resolve(__dirname, 'files', '_underscore-test-patterns');
-  var eol = require('os').EOL;
+var path = require('path');
+var pa = require('../core/lib/pattern_assembler');
+var testPatternsPath = path.resolve(__dirname, 'files', '_underscore-test-patterns');
+var eol = require('os').EOL;
 
-  try {
-    require('underscore');
-  } catch (err) {
-    console.log('underscore renderer not installed; skipping tests');
-    return;
-  }
-
-  // fake pattern lab constructor:
-  // sets up a fake patternlab object, which is needed by the pattern processing
-  // apparatus.
-  function fakePatternLab() {
-    var fpl = {
-      partials: {},
-      patterns: [],
-      footer: '',
-      header: '',
-      listitems: {},
-      listItemArray: [],
-      data: {
-        link: {}
-      },
-      config: require('../patternlab-config.json'),
-      package: {}
-    };
-
-    // patch the pattern source so the pattern assembler can correctly determine
-    // the "subdir"
-    fpl.config.paths.source.patterns = testPatternsPath;
-
-    return fpl;
-  }
-
-  exports['engine_underscore'] = {
-    'hello world underscore pattern renders': function (test) {
-      test.expect(1);
-
-      var patternPath = path.resolve(
-        testPatternsPath,
-        '00-atoms',
-        '00-global',
-        '00-helloworld.html'
-      );
-
-      // do all the normal processing of the pattern
-      var patternlab = new fakePatternLab();
-      var assembler = new pa();
-      var helloWorldPattern = assembler.process_pattern_iterative(patternPath, patternlab);
-      assembler.process_pattern_recursive(patternPath, patternlab);
-
-      test.equals(helloWorldPattern.render(), 'Hello world!' + eol);
-      test.done();
+// fake pattern lab constructor:
+// sets up a fake patternlab object, which is needed by the pattern processing
+// apparatus.
+function fakePatternLab() {
+  var fpl = {
+    partials: {},
+    patterns: [],
+    footer: '',
+    header: '',
+    listitems: {},
+    listItemArray: [],
+    data: {
+      link: {}
     },
-    'underscore partials can render JSON values': function (test) {
-      test.expect(1);
-
-      // pattern paths
-      var pattern1Path = path.resolve(
-        testPatternsPath,
-        '00-atoms',
-        '00-global',
-        '00-helloworld-withdata.html'
-      );
-
-      // set up environment
-      var patternlab = new fakePatternLab(); // environment
-      var assembler = new pa();
-
-      // do all the normal processing of the pattern
-      var helloWorldWithData = assembler.process_pattern_iterative(pattern1Path, patternlab);
-      assembler.process_pattern_recursive(pattern1Path, patternlab);
-
-      // test
-      test.equals(helloWorldWithData.render(), 'Hello world!' + eol + 'Yeah, we got the subtitle from the JSON.' + eol);
-      test.done();
-    }
+    config: require('../patternlab-config.json'),
+    package: {}
   };
-})();
+
+  // patch the pattern source so the pattern assembler can correctly determine
+  // the "subdir"
+  fpl.config.paths.source.patterns = testPatternsPath;
+
+  return fpl;
+}
+
+exports['engine_underscore'] = {
+  'hello world underscore pattern renders': function (test) {
+    test.expect(1);
+
+    var patternPath = path.resolve(
+      testPatternsPath,
+      '00-atoms',
+      '00-global',
+      '00-helloworld.html'
+    );
+
+    // do all the normal processing of the pattern
+    var patternlab = new fakePatternLab();
+    var assembler = new pa();
+    var helloWorldPattern = assembler.process_pattern_iterative(patternPath, patternlab);
+    assembler.process_pattern_recursive(patternPath, patternlab);
+
+    test.equals(helloWorldPattern.render(), 'Hello world!' + eol);
+    test.done();
+  },
+  'underscore partials can render JSON values': function (test) {
+    test.expect(1);
+
+    // pattern paths
+    var pattern1Path = path.resolve(
+      testPatternsPath,
+      '00-atoms',
+      '00-global',
+      '00-helloworld-withdata.html'
+    );
+
+    // set up environment
+    var patternlab = new fakePatternLab(); // environment
+    var assembler = new pa();
+
+    // do all the normal processing of the pattern
+    var helloWorldWithData = assembler.process_pattern_iterative(pattern1Path, patternlab);
+    assembler.process_pattern_recursive(pattern1Path, patternlab);
+
+    // test
+    test.equals(helloWorldWithData.render(), 'Hello world!' + eol + 'Yeah, we got the subtitle from the JSON.' + eol);
+    test.done();
+  }
+};
+
+
+
+// don't run these tests unless underscore is installed
+var engineLoader = require('../core/lib/pattern_engines');
+if (!engineLoader.underscore) {
+  console.log("Underscore engine not installed, skipping tests.");
+  delete exports.engine_underscore;
+}


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #352.

Summary of changes:
 - Stop doing the hackish `return;` before the main body of code. My editor pointed out, I think rightly, that this is not okay. Instead, we do a check at the end and then wipe out the exports of the module.
 - The check itself now uses the real engine loader as the source of truth, which I hope will be more accurate.
 - We now pass tests!

There are some more alarming changes in the underscore test file, but all I did was remove the IIFE around the module body and clean stuff up.