### PR TITLE
Add support to expand link.patternPartials inside listitems

### DIFF
--- a/core/lib/list_item_hunter.js
+++ b/core/lib/list_item_hunter.js
@@ -47,7 +47,9 @@ var list_item_hunter = function () {
           console.log('There was an error parsing JSON for ' + pattern.relPath);
           console.log(err);
         }
+
         listData = plutils.mergeData(listData, pattern.listitems);
+        listData = pattern_assembler.parse_data_links_specific(patternlab, listData, 'listitems.json + any pattern listitems.json');
 
         //iterate over each copied block, rendering its contents along with pattenlab.listitems[i]
         for (var i = 0; i < repeatedBlockTemplate.length; i++) {

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -16,7 +16,7 @@ var Pattern = function (relPath, data) {
   this.fileExtension = pathObj.ext; // '.mustache'
 
   // this is the unique name, subDir + fileName (sans extension)
-  this.name = this.subdir.replace(/[\/\\]/g, '-') + '-' + this.fileName; // '00-atoms-00-global-00-colors'
+  this.name = this.subdir.replace(/[\/\\]/g, '-') + '-' + this.fileName.replace('~', '-'); // '00-atoms-00-global-00-colors'
 
   // the JSON used to render values in the pattern
   this.jsonFileData = data || {};

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -4,6 +4,7 @@ var pattern_assembler = function () {
   var path = require('path'),
     fs = require('fs-extra'),
     Pattern = require('./object_factory').Pattern,
+    pph = require('./pseudopattern_hunter'),
     md = require('markdown-it')(),
     plutils = require('./utilities'),
     patternEngines = require('./pattern_engines');
@@ -123,6 +124,9 @@ var pattern_assembler = function () {
   }
 
   function processPatternIterative(relPath, patternlab) {
+
+    var pseudopattern_hunter = new pph();
+
     //extract some information
     var filename = path.basename(relPath);
     var ext = path.extname(filename);
@@ -198,17 +202,18 @@ var pattern_assembler = function () {
     //add currentPattern to patternlab.patterns array
     addPattern(currentPattern, patternlab);
 
+    //look for a pseudo pattern by checking if there is a file containing same name, with ~ in it, ending in .json
+    pseudopattern_hunter.find_pseudopatterns(currentPattern, patternlab);
+
     return currentPattern;
   }
 
   function processPatternRecursive(file, patternlab) {
     var lh = require('./lineage_hunter'),
-      pph = require('./pseudopattern_hunter'),
       lih = require('./list_item_hunter');
 
     var lineage_hunter = new lh(),
-      list_item_hunter = new lih(),
-      pseudopattern_hunter = new pph();
+      list_item_hunter = new lih();
 
     //find current pattern in patternlab object using var file as a partial
     var currentPattern, i;
@@ -247,9 +252,6 @@ var pattern_assembler = function () {
 
     //add to patternlab object so we can look these up later.
     addPattern(currentPattern, patternlab);
-
-    //look for a pseudo pattern by checking if there is a file containing same name, with ~ in it, ending in .json
-    pseudopattern_hunter.find_pseudopatterns(currentPattern, patternlab);
   }
 
   function expandPartials(foundPatternPartials, list_item_hunter, patternlab, currentPattern) {
@@ -376,6 +378,9 @@ var pattern_assembler = function () {
     },
     parse_data_links: function (patternlab) {
       parseDataLinks(patternlab);
+    },
+    parse_data_links_specific: function (patternlab, data, label){
+      return parseDataLinksHelper(patternlab, data, label)
     }
   };
 

--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -42,6 +42,7 @@ var pseudopattern_hunter = function () {
         var patternVariant = Pattern.create(variantFilePath, variantFileData, {
           //use the same template as the non-variant
           template: currentPattern.template,
+          fileExtension: currentPattern.fileExtension,
           extendedTemplate: currentPattern.extendedTemplate,
           isPseudoPattern: true,
           basePattern: currentPattern,

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -11,7 +11,7 @@ var eol = require('os').EOL;
 
 function addToPatternPaths(patternlab, patternTypeName, pattern) {
   //this is messy, could use a refactor.
-  patternlab.patternPaths[patternTypeName][pattern.patternBaseName] = pattern.subdir.replace(/\\/g, '/') + "/" + pattern.fileName;
+  patternlab.patternPaths[patternTypeName][pattern.patternBaseName] = pattern.subdir.replace(/\\/g, '/') + "/" + pattern.fileName.replace('~', '-');
 }
 
 //todo: refactor this as a method on the pattern object itself once we merge dev with pattern-engines branch

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -538,63 +538,6 @@
 			test.equals(bookendPattern.extendedTemplate.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim(), expectedValue.trim());
 			test.done();
 		},
-		'processPatternIterative - ignores files that are variants' : function(test){
-			//arrange
-			var diveSync = require('diveSync');
-			var fs = require('fs-extra');
-			var pa = require('../core/lib/pattern_assembler');
-			var pattern_assembler = new pa();
-			var patterns_dir = './test/files/_patterns';
-			var patternlab = {};
-			//THIS IS BAD.
-			patternlab.config = fs.readJSONSync('./patternlab-config.json');
-			patternlab.config.paths.source.patterns = patterns_dir;
-
-			//patternlab.data = fs.readJSONSync(path.resolve(patternlab.config.paths.source.data, 'data.json'));
-      patternlab.data = {};
-			//patternlab.listitems = fs.readJSONSync(path.resolve(patternlab.config.paths.source.data, 'listitems.json'));
-      patternlab.listitems = {};
-			//patternlab.header = fs.readFileSync(path.resolve(patternlab.config.paths.source.patternlabFiles, 'templates/pattern-header-footer/header.html'), 'utf8');
-      patternlab.header = '';
-			//patternlab.footer = fs.readFileSync(path.resolve(patternlab.config.paths.source.patternlabFiles, 'templates/pattern-header-footer/footer.html'), 'utf8');
-      patternlab.footer = '';
-			patternlab.patterns = [];
-			patternlab.data.link = {};
-			patternlab.partials = {};
-
-			//act
-			diveSync(patterns_dir,
-				{
-					filter: function(path, dir){
-						if(dir){
-							var remainingPath = path.replace(patterns_dir, '');
-							var isValidPath = remainingPath.indexOf('/_') === -1;
-							return isValidPath;
-						}
-						return true;
-					}
-				},
-				function(err, file){
-					//log any errors
-					if(err){
-						console.log(err);
-						return;
-					}
-
-					pattern_assembler.process_pattern_iterative(path.resolve(file), patternlab);
-				}
-			);
-
-			//assert
-			var foundVariant = false;
-			for(var i = 0; i < patternlab.patterns.length; i++){
-				if(patternlab.patterns[i].fileName.indexOf('~') > -1){
-					foundVariant = true;
-				}
-			}
-			test.equals(foundVariant, false);
-			test.done();
-		},
 		'setState - applies any patternState matching the pattern' : function(test){
 			//arrange
 			var pa = require('../core/lib/pattern_assembler');


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #368

Summary of changes:

* expanding links found in listitems.json
* improve writing of pseudopatterns to disc - no longer have the tilde in the paths
* moved the search for pseudo-pattern variants to processPatternsIterative. dont know why it wasnt always there