### PR TITLE
pattern-object-schema-to-match-php

### DIFF
--- a/core/lib/list_item_hunter.js
+++ b/core/lib/list_item_hunter.js
@@ -74,7 +74,7 @@ var list_item_hunter = function () {
           allData.link = extend({}, patternlab.data.link);
 
           //check for partials within the repeated block
-          var foundPartials = Pattern.createEmpty({'template': thisBlockTemplate}).findPartials();
+          var foundPartials = Pattern.createEmpty({'template': thisBlockTemplate, 'extendedTemplate': thisBlockTemplate}).findPartials();
 
           if (foundPartials && foundPartials.length > 0) {
 

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -21,8 +21,8 @@ var Pattern = function (relPath, data) {
   // the JSON used to render values in the pattern
   this.jsonFileData = data || {};
 
-  // strip leading "00-" from the file name and underscores from ui-hidden patterns
-  this.patternBaseName = this.fileName.replace(/^\d*\-/, '').replace(/^_/, ''); // 'colors'
+  // strip leading "00-" from the file name and flip tildes to dashes
+  this.patternBaseName = this.fileName.replace(/^\d*\-/, '').replace('~', '-'); // 'colors'
 
   // Fancy name. No idea how this works. 'Colors'
   this.patternName = this.patternBaseName.split('-').reduce(function (val, working) {

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -16,13 +16,13 @@ var Pattern = function (relPath, data) {
   this.fileExtension = pathObj.ext; // '.mustache'
 
   // this is the unique name, subDir + fileName (sans extension)
-  this.name = this.subdir.replace(/[\/\\]/g, '-') + '-' + this.fileName.replace('~', '-'); // '00-atoms-00-global-00-colors'
+  this.name = this.subdir.replace(/[\/\\]/g, '-') + '-' + this.fileName.replace(/~/g, '-'); // '00-atoms-00-global-00-colors'
 
   // the JSON used to render values in the pattern
   this.jsonFileData = data || {};
 
-  // strip leading "00-" from the file name and flip tildes to dashes
-  this.patternBaseName = this.fileName.replace(/^\d*\-/, '').replace('~', '-'); // 'colors'
+  // strip leading "00-" from the file name and underscores from ui-hidden patterns
+  this.patternBaseName = this.fileName.replace(/^\d*\-/, '').replace(/^_/, ''); // 'colors'
 
   // Fancy name. No idea how this works. 'Colors'
   this.patternName = this.patternBaseName.split('-').reduce(function (val, working) {

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -21,8 +21,17 @@ var pattern_assembler = function () {
   function getPartial(partialName, patternlab) {
     //look for exact partial matches
     for (var i = 0; i < patternlab.patterns.length; i++) {
-      if (patternlab.patterns[i].patternPartial === partialName) {
-        return patternlab.patterns[i];
+      var pattern = patternlab.patterns[i];
+
+      if (pattern.patternPartial === partialName) {
+        return pattern;
+
+      //also check for Pattern Lab PHP syntax for hidden patterns
+      //Pattern Lab PHP strips leading underscores from pattern filenames,
+      //strips leading digits plus hyphen,
+      //and retains the first tilde instead of replacing it with a hyphen
+      } else if (partialName === pattern.patternGroup + '-' + pattern.fileName.replace(/^_/, '').replace(/^\d*\-/, '')) {
+        return pattern;
       }
     }
 

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -122,7 +122,7 @@ function buildNavigation(patternlab) {
     patternSubTypeName = pattern.subdir.split(path.sep).pop().replace(/^\d*\-/, '');
 
     //get the patternSubTypeItem
-    patternSubTypeItemName = pattern.patternName.replace(/-/g, ' ');
+    patternSubTypeItemName = pattern.patternName.replace(/[\-~]/g, ' ');
 
     //assume the patternSubTypeItem does not exist.
     patternSubTypeItem = new of.oPatternSubTypeItem(patternSubTypeItemName);

--- a/test/engine_mustache_tests.js
+++ b/test/engine_mustache_tests.js
@@ -42,7 +42,8 @@ function testFindPartials(test, partialTests) {
     '01-molecules/00-testing/00-test-mol.mustache', // relative path now
     null, // data
     {
-      template: partialTests.join(eol)
+      template: partialTests.join(eol),
+      extendedTemplate: partialTests.join(eol)
     }
   );
 
@@ -68,7 +69,8 @@ function testFindPartialsWithStyleModifiers(test, partialTests) {
     '01-molecules/00-testing/00-test-mol.mustache', // relative path now
     null, // data
     {
-      template: partialTests.join(eol)
+      template: partialTests.join(eol),
+      extendedTemplate: partialTests.join(eol)
     }
   );
 
@@ -94,7 +96,8 @@ function testFindPartialsWithPatternParameters(test, partialTests) {
     '01-molecules/00-testing/00-test-mol.mustache', // relative path now
     null, // data
     {
-      template: partialTests.join(eol)
+      template: partialTests.join(eol),
+      extendedTemplate: partialTests.join(eol)
     }
   );
 

--- a/test/pseudopattern_hunter_tests.js
+++ b/test/pseudopattern_hunter_tests.js
@@ -40,7 +40,7 @@ exports['pseudopattern_hunter'] = {
 
     //assert
     test.equals(patternCountBefore + 1, pl.patterns.length);
-    test.equals(pl.patterns[1].patternPartial, 'test-styled-atom-alt');
+    test.equals(pl.patterns[1].patternPartial, 'test-styled-atom~alt');
     test.equals(pl.patterns[1].extendedTemplate.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim(), '<span class="test_base {{styleModifier}}"> {{message}} </span>');
     test.equals(JSON.stringify(pl.patterns[1].jsonFileData), JSON.stringify({"message": "alternateMessage"}));
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #250 precursor

Summary of changes:
In order to test large pattern sets, I needed to copy over a source dir from Pattern Lab PHP. In order use this dir without exhaustively changing tags, I needed to make these changes.
- The `.name` param required that all tildes be switched to hyphens, not just the first. I use tildes liberally in filenames. No harm switching all of them to hyphens for this sort of edge-case.
- The `patternBaseName` param required that no tildes be switched to hyphens. This is purely to match PHP's implementation.
- The `patternBaseName` param required that leading underscores in filenames be stripped. This also matches PHP's implementation.
