### PR TITLE
Repurposing patternlab.partials

### DIFF
--- a/core/lib/list_item_hunter.js
+++ b/core/lib/list_item_hunter.js
@@ -106,11 +106,11 @@ var list_item_hunter = function () {
             }
 
             //render with data
-            thisBlockHTML = pattern_assembler.renderPattern(thisBlockTemplate, allData, patternlab.partials);
+            thisBlockHTML = pattern_assembler.renderPattern(thisBlockTemplate, allData);
 
           } else {
             //just render with mergedData
-            thisBlockHTML = pattern_assembler.renderPattern(thisBlockTemplate, allData, patternlab.partials);
+            thisBlockHTML = pattern_assembler.renderPattern(thisBlockTemplate, allData);
           }
 
           //add the rendered HTML to our string
@@ -120,9 +120,6 @@ var list_item_hunter = function () {
         //replace the block with our generated HTML
         var repeatingBlock = pattern.extendedTemplate.substring(pattern.extendedTemplate.indexOf(liMatch), pattern.extendedTemplate.indexOf(end) + end.length);
         pattern.extendedTemplate = pattern.extendedTemplate.replace(repeatingBlock, repeatedBlockHtml);
-
-        //update the extendedTemplate in the partials object in case this pattern is consumed later
-        patternlab.partials[pattern.patternPartial] = pattern.extendedTemplate;
 
       });
     }

--- a/core/lib/list_item_hunter.js
+++ b/core/lib/list_item_hunter.js
@@ -128,7 +128,8 @@ var list_item_hunter = function () {
   return {
     process_list_item_partials: function (pattern, patternlab) {
       processListItemPartials(pattern, patternlab);
-    }
+    },
+    items: items
   };
 };
 

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -57,6 +57,7 @@ var Pattern = function (relPath, data) {
   this.isPseudoPattern = false;
   this.engine = patternEngines.getEngineForPattern(this);
   this.patternPartials = null;
+  this.allData = {};
   this.dataKeys = [];
 };
 

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -57,6 +57,7 @@ var Pattern = function (relPath, data) {
   this.isPseudoPattern = false;
   this.engine = patternEngines.getEngineForPattern(this);
   this.patternPartials = null;
+  this.dataKeys = [];
 };
 
 // Pattern methods

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -56,6 +56,7 @@ var Pattern = function (relPath, data) {
   this.lineageRIndex = [];
   this.isPseudoPattern = false;
   this.engine = patternEngines.getEngineForPattern(this);
+  this.patternPartials = null;
 };
 
 // Pattern methods

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -100,7 +100,6 @@ var pattern_assembler = function () {
       if (pattern.relPath === patternlab.patterns[i].relPath) {
         //if relPath already exists, overwrite that element
         patternlab.patterns[i] = pattern;
-        patternlab.partials[pattern.patternPartial] = pattern.extendedTemplate || pattern.template;
         isNew = false;
         break;
       }
@@ -117,12 +116,8 @@ var pattern_assembler = function () {
 
 
       if (pattern.isPattern) {
-        patternlab.partials[pattern.patternPartial] = pattern.extendedTemplate || pattern.template;
-
         // do plugin-specific registration
         pattern.registerPartial();
-      } else {
-        patternlab.partials[pattern.patternPartial] = pattern.patternDesc;
       }
 
       patternlab.patterns.push(pattern);
@@ -353,10 +348,6 @@ var pattern_assembler = function () {
     if (currentPattern.engine.expandPartials && (foundPatternPartials !== null && foundPatternPartials.length > 0)) {
       // eslint-disable-next-line
       expandPartials(foundPatternPartials, list_item_hunter, patternlab, currentPattern);
-
-      // update the extendedTemplate in the partials object in case this
-      // pattern is consumed later
-      patternlab.partials[currentPattern.patternPartial] = currentPattern.extendedTemplate;
     }
 
     //find pattern lineage

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -277,6 +277,7 @@ var pattern_assembler = function () {
 
     //add allData keys to currentPattern.dataKeys
     currentPattern.dataKeys = getDataKeys(currentPattern.allData, []);
+    //add listItem keys to currentPattern.dataKeys
     for (var i = 0; i < list_item_hunter.items.length; i++) {
       currentPattern.dataKeys.push('listItems.' + list_item_hunter.items[i]);
       currentPattern.dataKeys.push('listitems.' + list_item_hunter.items[i]);

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -112,10 +112,10 @@ var pattern_assembler = function () {
         console.log('found new pattern ' + pattern.patternPartial);
       }
 
-      // do global registration
-
-
       if (pattern.isPattern) {
+        //TODO: Next line slated for deletion. Here only to pass unit tests.
+        patternlab.partials[pattern.patternPartial] = pattern.extendedTemplate || pattern.template;
+
         // do plugin-specific registration
         pattern.registerPartial(patternlab);
       }
@@ -225,6 +225,7 @@ var pattern_assembler = function () {
 
     }
 
+    var list_item_hunter = new lih();
     var pseudopattern_hunter = new pph();
 
     //extract some information

--- a/core/lib/style_modifier_hunter.js
+++ b/core/lib/style_modifier_hunter.js
@@ -16,9 +16,6 @@ var style_modifier_hunter = function () {
 
       //replace the stylemodifier placeholder with the class name
       pattern.extendedTemplate = pattern.extendedTemplate.replace(/{{[ ]?styleModifier[ ]?}}/i, styleModifier);
-
-      //update the extendedTemplate in the partials object in case this pattern is consumed later
-      patternlab.partials[pattern.patternPartial] = pattern.extendedTemplate;
     }
   }
 

--- a/test/parameter_hunter_tests.js
+++ b/test/parameter_hunter_tests.js
@@ -6,6 +6,7 @@
   //setup current pattern from what we would have during execution
   function currentPatternClosure() {
     return {
+      "relPath": "02-organisms/02-comments/01-sticky-comment.mustache",
       "fileName": "01-sticky-comment",
       "subdir": "02-organisms/02-comments",
       "name": "02-organisms-02-comments-01-sticky-comment",
@@ -28,6 +29,7 @@
     return {
       patterns: [
         {
+          "relPath": "01-molecules/06-components/02-single-comment.mustache",
           "fileName": "02-single-comment",
           "subdir": "01-molecules/06-components",
           "name": "01-molecules-06-components-02-single-comment",


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #250 precursor

Summary of changes:
- patternlab.partials will be reserved for a patternengine-node-mustache-specific registration operation
- adding some more properties on the `pattern` object
