### PR TITLE
Find partial to get partial

### DIFF
--- a/core/lib/lineage_hunter.js
+++ b/core/lib/lineage_hunter.js
@@ -13,7 +13,7 @@ var lineage_hunter = function () {
     if (matches !== null) {
       matches.forEach(function (match) {
         //get the ancestorPattern
-        var ancestorPattern = pattern_assembler.findPartial(pattern.findPartial(match), patternlab);
+        var ancestorPattern = pattern_assembler.getPartial(pattern.findPartial(match), patternlab);
 
         if (ancestorPattern && pattern.lineageIndex.indexOf(ancestorPattern.patternPartial) === -1) {
           //add it since it didnt exist
@@ -83,7 +83,7 @@ var lineage_hunter = function () {
 
           //find all lineage - patterns being consumed by this one
           for (var h = 0; h < pattern.lineageIndex.length; h++) {
-            var lineagePattern = pattern_assembler.findPartial(pattern.lineageIndex[h], patternlab);
+            var lineagePattern = pattern_assembler.getPartial(pattern.lineageIndex[h], patternlab);
             setPatternState('fromFuture', lineagePattern, pattern);
           }
         }
@@ -93,7 +93,7 @@ var lineage_hunter = function () {
           //find all reverse lineage - that is, patterns consuming this one
           for (var j = 0; j < pattern.lineageRIndex.length; j++) {
 
-            var lineageRPattern = pattern_assembler.findPartial(pattern.lineageRIndex[j], patternlab);
+            var lineageRPattern = pattern_assembler.getPartial(pattern.lineageRIndex[j], patternlab);
 
             //only set patternState if pattern.patternState "is less than" the lineageRPattern.patternstate
             //or if lineageRPattern.patternstate (the consuming pattern) does not have a state

--- a/core/lib/list_item_hunter.js
+++ b/core/lib/list_item_hunter.js
@@ -82,7 +82,7 @@ var list_item_hunter = function () {
 
               //get the partial
               var partialName = foundPartials[j].match(/([\w\-\.\/~]+)/g)[0];
-              var partialPattern = pattern_assembler.findPartial(partialName, patternlab);
+              var partialPattern = pattern_assembler.getPartial(partialName, patternlab);
 
               //create a copy of the partial so as to not pollute it after the get_pattern_by_key call.
               var cleanPartialPattern;

--- a/core/lib/parameter_hunter.js
+++ b/core/lib/parameter_hunter.js
@@ -240,7 +240,7 @@ var parameter_hunter = function () {
       pattern.parameteredPartials.forEach(function (pMatch) {
         //find the partial's name and retrieve it
         var partialName = pMatch.match(/([\w\-\.\/~]+)/g)[0];
-        var partialPattern = pattern_assembler.findPartial(partialName, patternlab);
+        var partialPattern = pattern_assembler.getPartial(partialName, patternlab);
 
         //if we retrieved a pattern we should make sure that its extendedTemplate is reset. looks to fix #190
         partialPattern.extendedTemplate = partialPattern.template;

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -29,8 +29,8 @@ var pattern_assembler = function () {
     //else look by verbose syntax
     for (var i = 0; i < patternlab.patterns.length; i++) {
       switch (partialName) {
+        case patternlab.patterns[i].relPath:
         case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName:
-        case patternlab.patterns[i].subdir + '/' + patternlab.patterns[i].fileName + '.mustache':
           return patternlab.patterns[i];
       }
     }

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -45,7 +45,7 @@ var pattern_assembler = function () {
         return patternlab.patterns[i];
       }
     }
-    throw 'Could not find pattern with partial ' + partialName;
+    console.error('Could not find pattern with partial ' + partialName);
   }
 
   function buildListItems(container) {

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -483,7 +483,7 @@ var pattern_assembler = function () {
     process_pattern_recursive: function (file, patternlab, additionalData) {
       processPatternRecursive(file, patternlab, additionalData);
     },
-    findPartial: function (partial, patternlab) {
+    getPartial: function (partial, patternlab) {
       return getPartial(partial, patternlab);
     },
     combine_listItems: function (patternlab) {

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -46,6 +46,7 @@ var pattern_assembler = function () {
       }
     }
     console.error('Could not find pattern with partial ' + partialName);
+    return undefined;
   }
 
   function buildListItems(container) {

--- a/test/lineage_hunter_tests.js
+++ b/test/lineage_hunter_tests.js
@@ -178,7 +178,7 @@ exports['lineage hunter '] = {
     lineage_hunter.cascade_pattern_states(pl);
 
     //assert
-    var consumerPatternReturned = pattern_assembler.findPartial('test-foo', pl);
+    var consumerPatternReturned = pattern_assembler.getPartial('test-foo', pl);
     test.equals(consumerPatternReturned.patternState, 'inreview');
     test.done();
   },
@@ -206,7 +206,7 @@ exports['lineage hunter '] = {
     lineage_hunter.cascade_pattern_states(pl);
 
     //assert
-    var consumerPatternReturned = pattern_assembler.findPartial('test-foo', pl);
+    var consumerPatternReturned = pattern_assembler.getPartial('test-foo', pl);
     test.equals(consumerPatternReturned.lineage[0].lineageState, 'inreview');
     test.done();
   },
@@ -233,7 +233,7 @@ exports['lineage hunter '] = {
     lineage_hunter.cascade_pattern_states(pl);
 
     //assert
-    var consumedPatternReturned = pattern_assembler.findPartial('test-bar', pl);
+    var consumedPatternReturned = pattern_assembler.getPartial('test-bar', pl);
     test.equals(consumedPatternReturned.lineageR[0].lineageState, 'inreview');
 
     test.done();
@@ -261,7 +261,7 @@ exports['lineage hunter '] = {
     lineage_hunter.cascade_pattern_states(pl);
 
     //assert
-    var consumerPatternReturned = pattern_assembler.findPartial('test-foo', pl);
+    var consumerPatternReturned = pattern_assembler.getPartial('test-foo', pl);
     test.equals(consumerPatternReturned.lineage.length, 1);
     test.equals(consumerPatternReturned.lineage[0].lineageState, 'inreview');
     test.equals(consumerPatternReturned.patternState, 'inreview');

--- a/test/parameter_hunter_tests.js
+++ b/test/parameter_hunter_tests.js
@@ -6,6 +6,7 @@
   //setup current pattern from what we would have during execution
   function currentPatternClosure() {
     return {
+      "relPath": "02-organisms/02-comments/01-sticky-comment.mustache",
       "fileName": "01-sticky-comment",
       "subdir": "02-organisms/02-comments",
       "name": "02-organisms-02-comments-01-sticky-comment",
@@ -28,6 +29,7 @@
     return {
       patterns: [
         {
+          "relPath": "01-molecules/06-components/02-single-comment.mustache",
           "fileName": "02-single-comment",
           "subdir": "01-molecules/06-components",
           "name": "01-molecules-06-components-02-single-comment",

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -419,7 +419,7 @@
 			});
 
 			//act
-			var result = pattern_assembler.findPartial('character-han', patternlab);
+			var result = pattern_assembler.getPartial('character-han', patternlab);
 			//assert
 			test.equals(result, patternlab.patterns[0]);
 			test.done();
@@ -441,7 +441,7 @@
 			});
 
 			//act
-			var result = pattern_assembler.findPartial('molecules-primary-nav', patternlab);
+			var result = pattern_assembler.getPartial('molecules-primary-nav', patternlab);
 			//assert
 			test.equals(result, patternlab.patterns[1]);
 			test.done();


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #407 

Summary of changes:
@bmuenzenmeyer 
Mostly just simple name changes. This helps when grepping for one function vs the other.

Also includes minor updates to the getPartial function itself. One avoids string-concatenation and the hard-coded "mustache" extension. Another replaces `throw` with `console.error` because `throw` throws misleading messages when the error is nothing more than a match not being found.