### PR TITLE
processing-but-hiding-underscore-prefixed-dirs

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -32,16 +32,6 @@ function buildPatternData(dataFilesPath, fs) {
 function processAllPatternsIterative(pattern_assembler, patterns_dir, patternlab) {
   diveSync(
     patterns_dir,
-    {
-      filter: function (thisPath, dir) {
-        if (dir) {
-          var remainingPath = thisPath.replace(patterns_dir, '');
-          var isValidPath = remainingPath.indexOf('/_') === -1;
-          return isValidPath;
-        }
-        return true;
-      }
-    },
     function (err, file) {
       //log any errors
       if (err) {
@@ -56,16 +46,6 @@ function processAllPatternsIterative(pattern_assembler, patterns_dir, patternlab
 function processAllPatternsRecursive(pattern_assembler, patterns_dir, patternlab) {
   diveSync(
     patterns_dir,
-    {
-      filter: function (thisPath, dir) {
-        if (dir) {
-          var remainingPath = thisPath.replace(patterns_dir, '');
-          var isValidPath = remainingPath.indexOf('/_') === -1;
-          return isValidPath;
-        }
-        return true;
-      }
-    },
     function (err, file) {
       //log any errors
       if (err) {

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -20,7 +20,7 @@ function addToPatternPaths(patternlab, pattern) {
 
 //todo: refactor this as a method on the pattern object itself once we merge dev with pattern-engines branch
 function isPatternExcluded(pattern) {
-  // returns whether or not the first character of the pattern type, subtype, other nested dirs, or filename is an underscore
+  // returns whether or not the first character of the pattern type, subtype, further nested dirs, or filename is an underscore
   if (pattern.isPattern) {
     if (
       pattern.relPath.charAt(0) === '_' ||

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -20,7 +20,7 @@ function addToPatternPaths(patternlab, pattern) {
 
 //todo: refactor this as a method on the pattern object itself once we merge dev with pattern-engines branch
 function isPatternExcluded(pattern) {
-  // returns whether or not the first character of the pattern group, nested dirs, or filename is an underscore
+  // returns whether or not the first character of the pattern type, subtype, other nested dirs, or filename is an underscore
   if (pattern.isPattern) {
     if (
       pattern.relPath.charAt(0) === '_' ||

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -20,8 +20,16 @@ function addToPatternPaths(patternlab, pattern) {
 
 //todo: refactor this as a method on the pattern object itself once we merge dev with pattern-engines branch
 function isPatternExcluded(pattern) {
-  // returns whether or not the first character of the pattern filename is an underscore, or excluded
-  return pattern.isPattern && pattern.fileName.charAt(0) === '_';
+  // returns whether or not the first character of the pattern group, nested dirs, or filename is an underscore
+  if (pattern.isPattern) {
+    if (
+      pattern.relPath.charAt(0) === '_' ||
+      pattern.relPath.indexOf('/_') > -1
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // Returns the array of patterns to be rendered in the styleguide view and


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #408 

Summary of changes:
Processing, but hiding from the UI, underscore-prefixed directories, since they are processed in PHP, and there is nothing in the spec forbidding them.