### PR TITLE
Support patternengine name rather than file extension in the template tab

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -339,6 +339,7 @@ var patternlab_engine = function (config) {
         patternName: pattern.patternName,
         patternPartial: pattern.patternPartial,
         patternState: pattern.patternState,
+        patternEngineName: pattern.engine.engineName,
         extraOutput: {}
       });
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #446 

Summary of changes:
Hey, it's a one-liner. We just drop the engine name into the pattern data block on the pattern's rendered html page. The UI can be updated to use it, but otherwise will ignore it.

See also:
* https://github.com/pattern-lab/styleguidekit-assets-default/issues/43
* https://github.com/pattern-lab/styleguidekit-assets-default/pull/44

Bonus: I believe this change is harmless even if support is missing in styleguidekit-assets-default. Likewise, I believe the proposed change to styleguidekit-assets-default is harmless even if this change isn't present.