### PR TITLE
Make listStarterkits return an array of repo objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "json5": "^0.5.0",
     "lodash": "~4.13.1",
     "markdown-it": "^6.0.1",
+    "node-fetch": "^1.6.0",
     "patternengine-node-mustache": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Addresses #462

Summary of changes:
- listStarterkits now fetches a list of repos 
- Returns a Promise<Array> with {name,url} per repo

