### PR TITLE
Add tap support for unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,13 @@ module.exports = function (grunt) {
     nodeunit: {
       all: ['test/*_tests.js']
     },
+    tape: {
+      options: {
+        pretty: true,
+        output: 'console'
+      },
+      files: ['test/*_tests.js']
+    },
     eslint: {
       options: {
         configFile: './.eslintrc'
@@ -31,11 +38,12 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-tape');
 
   //travis CI task
-  grunt.registerTask('travis', ['nodeunit', 'eslint']);
+  grunt.registerTask('travis', ['nodeunit', 'tape', 'eslint']);
 
   //to be run prior to releasing a version
-  grunt.registerTask('build', ['nodeunit', 'eslint', 'concat']);
+  grunt.registerTask('build', ['nodeunit', 'tape', 'eslint', 'concat']);
 
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "grunt": "~1.0.1",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-nodeunit": "^1.0.0",
-    "grunt-eslint": "^18.0.0"
+    "grunt-eslint": "^18.0.0",
+    "grunt-tape": "^0.1.0",
+    "tap": "^7.1.2"
   },
   "keywords": [
     "Pattern Lab",
@@ -44,7 +46,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "grunt travis --verbose"
+    "test": "node_modules/grunt/bin/grunt travis --verbose"
   },
   "engines": {
     "node": ">=4.0"

--- a/test/annotation_exporter_tests.js
+++ b/test/annotation_exporter_tests.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var eol = require('os').EOL;
-var Pattern = require('../core/lib/object_factory').Pattern;
+var tap = require('tap');
+
 var extend = require('util')._extend;
 var anPath = './test/files/';
 
@@ -22,59 +22,55 @@ function createFakePatternLab(anPath, customProps) {
 var patternlab = createFakePatternLab(anPath);
 var ae = require('../core/lib/annotation_exporter')(patternlab);
 
-exports['annotaton_exporter'] = {
+tap.test('converts old JS annotations into new format', function (test) {
+  //arrange
+  //act
+  var annotations = ae.gatherJS();
 
-  'converts old JS annotations into new format': function (test) {
-    //arrange
-    //act
-    var annotations = ae.gatherJS();
+  //assert
+  test.equals(annotations.length, 2);
+  test.equals(annotations[1].el, '.logo');
+  test.equals(annotations[1].title, 'Logo');
+  test.equals(annotations[1].comment, "The logo image is an SVG file, which ensures that the logo displays crisply even on high resolution displays. A PNG fallback is provided for browsers that don't support SVG images.</p><p>Further reading: <a href=\"http://bradfrostweb.com/blog/mobile/hi-res-optimization/\">Optimizing Web Experiences for High Resolution Screens</a></p>");
 
-    //assert
-    test.equals(annotations.length, 2);
-    test.equals(annotations[1].el, '.logo');
-    test.equals(annotations[1].title, 'Logo');
-    test.equals(annotations[1].comment, "The logo image is an SVG file, which ensures that the logo displays crisply even on high resolution displays. A PNG fallback is provided for browsers that don't support SVG images.</p><p>Further reading: <a href=\"http://bradfrostweb.com/blog/mobile/hi-res-optimization/\">Optimizing Web Experiences for High Resolution Screens</a></p>");
+  test.end();
+});
 
-    test.done();
-  },
+tap.test('converts new markdown annotations into an array', function (test) {
+  //arrange
+  //act
+  var annotations = ae.gatherMD();
 
-  'converts new markdown annotations into an array': function (test) {
-    //arrange
-    //act
-    var annotations = ae.gatherMD();
+  //assert
+  test.equals(annotations.length, 3);
+  test.equals(annotations[1].el, '.logo');
+  test.equals(annotations[1].title, 'Logo');
+  test.equals(annotations[1].comment.replace(/\r?\n|\r/gm, ""), '<p>The <em>logo image</em> is an SVG file.</p>');
 
-    //assert
-    test.equals(annotations.length, 3);
-    test.equals(annotations[1].el, '.logo');
-    test.equals(annotations[1].title, 'Logo');
-    test.equals(annotations[1].comment.replace(/\r?\n|\r/gm, ""), '<p>The <em>logo image</em> is an SVG file.</p>');
+  test.end();
+});
 
-    test.done();
-  },
+tap.test('merges both annotation methods into one array', function (test) {
+  //arrange
 
-  'merges both annotation methods into one array' : function (test) {
-    //arrange
+  //act
+  var annotations = ae.gather();
 
-    //act
-    var annotations = ae.gather();
+  //assert
+  test.equals(annotations.length, 3);
+  test.equals(annotations[2].el, '#nav');
+  test.equals(annotations[2].title, 'Navigation');
+  test.equals(annotations[2].comment.replace(/\r?\n|\r/gm, ""), '<p>Navigation for adaptive web experiences can be tricky. Refer to <a href="https://bradfrost.github.io/this-is-responsive/patterns.html#navigation">these repsonsive patterns</a> when evaluating solutions.</p>');
 
-    //assert
-    test.equals(annotations.length, 3);
-    test.equals(annotations[2].el, '#nav');
-    test.equals(annotations[2].title, 'Navigation');
-    test.equals(annotations[2].comment.replace(/\r?\n|\r/gm, ""), '<p>Navigation for adaptive web experiences can be tricky. Refer to <a href="https://bradfrost.github.io/this-is-responsive/patterns.html#navigation">these repsonsive patterns</a> when evaluating solutions.</p>');
+  test.end();
+});
 
-    test.done();
+tap.test('when there are 0 annotation files', function (test) {
+  var emptyAnPath = './test/files/empty/';
+  var patternlab2 = createFakePatternLab(emptyAnPath);
+  var ae2 = require('../core/lib/annotation_exporter')(patternlab2);
 
-  },
-
-  'when there are 0 annotation files' : function (test) {
-    var emptyAnPath = './test/files/empty/';
-    var patternlab2 = createFakePatternLab(emptyAnPath);
-    var ae2 = require('../core/lib/annotation_exporter')(patternlab2);
-
-    var annotations = ae2.gather();
-    test.equals(annotations.length, 0);
-    test.done();
-  }
-};
+  var annotations = ae2.gather();
+  test.equals(annotations.length, 0);
+  test.end();
+});


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #466

Summary of changes:
* Add support for tap based unit tests
* Create a tape grunt task to run the tests units
** Add the tape task to travis and build tasks
* Convert annotation_exporter_tests to use tap

