### PR TITLE
Fix relativeDepth check

### DIFF
--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -243,6 +243,7 @@ var pattern_assembler = function () {
   }
 
   function processPatternIterative(relPath, patternlab) {
+
     var relativeDepth = (relPath.match(/\w(?=\\)|\w(?=\/)/g) || []).length;
     if (relativeDepth > 2) {
       console.log('');

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -243,8 +243,7 @@ var pattern_assembler = function () {
   }
 
   function processPatternIterative(relPath, patternlab) {
-
-    var relativeDepth = relPath.match(/\w(?=\\)|\w(?=\/)/g || []).length;
+    var relativeDepth = (relPath.match(/\w(?=\\)|\w(?=\/)/g) || []).length;
     if (relativeDepth > 2) {
       console.log('');
       plutils.logOrange('Warning:');


### PR DESCRIPTION
Summary of changes:
- Fix syntax of depth check fallback in case of files at depth 0.

When parsing files at the 0th level (e.g., markdown associated with 1st-level folders), this regex returns `undefined`. The`|| []` was meant to guard against checking `.length` of `undefined`, but was ineffective due to this missing a pair of parentheses.

Should I attempt to add a test for this, or is it simple enough to go in as-is?
