### PR TITLE
Convert engine_underscore_tests.js to use tape

### DIFF
--- a/test/engine_underscore_tests.js
+++ b/test/engine_underscore_tests.js
@@ -1,9 +1,18 @@
 "use strict";
 
+var test = require('tape');
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var testPatternsPath = path.resolve(__dirname, 'files', '_underscore-test-patterns');
 var eol = require('os').EOL;
+
+// don't run tests unless underscore is installed
+var engineLoader = require('../core/lib/pattern_engines');
+if (!engineLoader.underscore) {
+  test.only('Underscore engine not installed, skipping tests', function (test){
+    test.end();
+  });
+}
 
 // fake pattern lab constructor:
 // sets up a fake patternlab object, which is needed by the pattern processing
@@ -30,67 +39,64 @@ function fakePatternLab() {
   return fpl;
 }
 
-exports['engine_underscore'] = {
-  'hello world underscore pattern renders': function (test) {
-    test.expect(1);
+test('hello world underscore pattern renders', function (test) {
+  test.plan(1);
 
-    var patternPath = path.resolve(
-      testPatternsPath,
-      '00-atoms',
-      '00-global',
-      '00-helloworld.html'
-    );
+  var patternPath = path.resolve(
+    testPatternsPath,
+    '00-atoms',
+    '00-global',
+    '00-helloworld.html'
+  );
 
-    // do all the normal processing of the pattern
-    var patternlab = new fakePatternLab();
-    var assembler = new pa();
-    var helloWorldPattern = assembler.process_pattern_iterative(patternPath, patternlab);
-    assembler.process_pattern_recursive(patternPath, patternlab);
+  // do all the normal processing of the pattern
+  var patternlab = new fakePatternLab();
+  var assembler = new pa();
+  var helloWorldPattern = assembler.process_pattern_iterative(patternPath, patternlab);
+  //test.comment(helloWorldPattern);
+  assembler.process_pattern_recursive(patternPath, patternlab);
 
-    test.equals(helloWorldPattern.render(), 'Hello world!' + eol);
-    test.done();
-  },
-  'underscore partials can render JSON values': function (test) {
-    test.expect(1);
+  test.equals(helloWorldPattern.render(), 'Hello world!' + eol);
+  test.end();
 
-    // pattern paths
-    var pattern1Path = path.resolve(
-      testPatternsPath,
-      '00-atoms',
-      '00-global',
-      '00-helloworld-withdata.html'
-    );
+});
 
-    // set up environment
-    var patternlab = new fakePatternLab(); // environment
-    var assembler = new pa();
+test('underscore partials can render JSON values', function (test) {
 
-    // do all the normal processing of the pattern
-    var helloWorldWithData = assembler.process_pattern_iterative(pattern1Path, patternlab);
-    assembler.process_pattern_recursive(pattern1Path, patternlab);
+  test.plan(1);
 
-    // test
-    test.equals(helloWorldWithData.render(), 'Hello world!' + eol + 'Yeah, we got the subtitle from the JSON.' + eol);
-    test.done();
-  },
-  'findPartial return the ID of the partial, given a whole partial call': function (test) {
-    var engineLoader = require('../core/lib/pattern_engines');
-    var underscoreEngine = engineLoader.underscore;
+  // pattern paths
+  var pattern1Path = path.resolve(
+    testPatternsPath,
+    '00-atoms',
+    '00-global',
+    '00-helloworld-withdata.html'
+  );
 
-    test.expect(1);
+  // set up environment
+  var patternlab = new fakePatternLab(); // environment
+  var assembler = new pa();
 
-    // do all the normal processing of the pattern
-    // test
-    test.equals(underscoreEngine.findPartial("<%= _.renderNamedPartial('molecules-details', obj) %>"), 'molecules-details');
-    test.done();
-  }
-};
+  // do all the normal processing of the pattern
+  var helloWorldWithData = assembler.process_pattern_iterative(pattern1Path, patternlab);
+  assembler.process_pattern_recursive(pattern1Path, patternlab);
 
+  // test
+  test.equals(helloWorldWithData.render(), 'Hello world!' + eol + 'Yeah, we got the subtitle from the JSON.' + eol);
+  test.end();
 
+});
 
-// don't run these tests unless underscore is installed
-var engineLoader = require('../core/lib/pattern_engines');
-if (!engineLoader.underscore) {
-  console.log("Underscore engine not installed, skipping tests.");
-  delete exports.engine_underscore;
-}
+test('findPartial return the ID of the partial, given a whole partial call', function (test) {
+  var engineLoader = require('../core/lib/pattern_engines');
+  var underscoreEngine = engineLoader.underscore;
+
+  test.plan(1);
+
+  // do all the normal processing of the pattern
+  // test
+  test.equals(underscoreEngine.findPartial("<%= _.renderNamedPartial('molecules-details', obj) %>"), 'molecules-details');
+  test.end();
+
+});
+

--- a/test/engine_underscore_tests.js
+++ b/test/engine_underscore_tests.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var test = require('tape');
+var tap = require('tap');
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var testPatternsPath = path.resolve(__dirname, 'files', '_underscore-test-patterns');
@@ -9,9 +9,10 @@ var eol = require('os').EOL;
 // don't run tests unless underscore is installed
 var engineLoader = require('../core/lib/pattern_engines');
 if (!engineLoader.underscore) {
-  test.only('Underscore engine not installed, skipping tests', function (test){
+  tap.test('Underscore engine not installed, skipping tests', function (test) {
     test.end();
   });
+  return;
 }
 
 // fake pattern lab constructor:
@@ -39,7 +40,7 @@ function fakePatternLab() {
   return fpl;
 }
 
-test('hello world underscore pattern renders', function (test) {
+tap.test('hello world underscore pattern renders', function (test) {
   test.plan(1);
 
   var patternPath = path.resolve(
@@ -53,7 +54,6 @@ test('hello world underscore pattern renders', function (test) {
   var patternlab = new fakePatternLab();
   var assembler = new pa();
   var helloWorldPattern = assembler.process_pattern_iterative(patternPath, patternlab);
-  //test.comment(helloWorldPattern);
   assembler.process_pattern_recursive(patternPath, patternlab);
 
   test.equals(helloWorldPattern.render(), 'Hello world!' + eol);
@@ -61,7 +61,7 @@ test('hello world underscore pattern renders', function (test) {
 
 });
 
-test('underscore partials can render JSON values', function (test) {
+tap.test('underscore partials can render JSON values', function (test) {
 
   test.plan(1);
 
@@ -87,7 +87,7 @@ test('underscore partials can render JSON values', function (test) {
 
 });
 
-test('findPartial return the ID of the partial, given a whole partial call', function (test) {
+tap.test('findPartial return the ID of the partial, given a whole partial call', function (test) {
   var engineLoader = require('../core/lib/pattern_engines');
   var underscoreEngine = engineLoader.underscore;
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #520  

Summary of changes:
- convert tests to tape

