### PR TITLE
Added patternlab-pattern-before-data-merge event to enable manipulati…

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -1,10 +1,10 @@
-/* 
- * patternlab-node - v2.6.0-alpha - 2016 
- * 
+/*
+ * patternlab-node - v2.6.0-alpha - 2016
+ *
  * Brian Muenzenmeyer, Geoff Pursell, and the web community.
- * Licensed under the MIT license. 
- * 
- * Many thanks to Brad Frost and Dave Olsen for inspiration, encouragement, and advice. 
+ * Licensed under the MIT license.
+ *
+ * Many thanks to Brad Frost and Dave Olsen for inspiration, encouragement, and advice.
  *
  */
 
@@ -356,6 +356,8 @@ var patternlab_engine = function (config) {
       pattern.patternLineagesR = pattern.lineageR;
       pattern.patternLineageRExists = pattern.lineageR.length > 0;
       pattern.patternLineageEExists = pattern.patternLineageExists || pattern.patternLineageRExists;
+
+      patternlab.events.emit('patternlab-pattern-before-data-merge', patternlab, pattern);
 
       //render the pattern, but first consolidate any data we may have
       var allData;


### PR DESCRIPTION
Summary of changes:
Added an additional event to patternlab.js to after pattern lineages have been set, and before global data has been merged with pattern data. The event is needed to be able to traverse/modify pattern data  before the merge occurs. 

We were trying to create a plugin similar to the data-inheritance plugin for php when we found there was no suitable event to hook onto. If the naming is incorrect according to any standard defined, I'll happily change it. 