### PR TITLE
#540 only rebuild changed templates via modification date (prototype)

### DIFF
--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var patternEngines = require('./pattern_engines');
+var fs = require('fs');
+var _ = require("lodash");
 var path = require('path');
 var extend = require('util')._extend;
 
@@ -63,6 +65,11 @@ var Pattern = function (relPath, data, patternlab) {
   this.lineageRIndex = [];
   this.isPseudoPattern = false;
   this.engine = patternEngines.getEngineForPattern(this);
+  // For completeness
+  this.compileState = null;
+  // The unix timestamp when the pattern was last modified
+  this.lastModified = null;
+
 };
 
 // Pattern methods
@@ -143,6 +150,13 @@ Pattern.create = function (relPath, data, customProps, patternlab) {
   return extend(newPattern, customProps);
 };
 
+var CompileState = {
+  NEEDS_REBUILD: "needs rebuild",
+  BUILDING: "building",
+  CLEAN: "clean"
+};
+
 module.exports = {
-  Pattern: Pattern
+  Pattern: Pattern,
+  CompileState: CompileState
 };

--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -33,7 +33,8 @@ var pseudopattern_hunter = function () {
 
         //we want to do everything we normally would here, except instead read the pseudoPattern data
         try {
-          var variantFileData = fs.readJSONSync(path.resolve(paths.source.patterns, pseudoPatterns[i]));
+          var variantFileFullPath = path.resolve(paths.source.patterns, pseudoPatterns[i]);
+          var variantFileData = fs.readJSONSync(variantFileFullPath);
         } catch (err) {
           console.log('There was an error parsing pseudopattern JSON for ' + currentPattern.relPath);
           console.log(err);
@@ -44,6 +45,7 @@ var pseudopattern_hunter = function () {
 
         var variantName = pseudoPatterns[i].substring(pseudoPatterns[i].indexOf('~') + 1).split('.')[0];
         var variantFilePath = path.join(currentPattern.subdir, currentPattern.fileName + '~' + variantName + '.json');
+        var lm = fs.statSync(variantFileFullPath);
         var patternVariant = Pattern.create(variantFilePath, variantFileData, {
           //use the same template as the non-variant
           template: currentPattern.template,
@@ -53,11 +55,14 @@ var pseudopattern_hunter = function () {
           basePattern: currentPattern,
           stylePartials: currentPattern.stylePartials,
           parameteredPartials: currentPattern.parameteredPartials,
-
+          // Only regular patterns are discovered during iterative walks
+          // Need to recompile on data change or template change
+          lastModified: Math.max(currentPattern.lastModified, lm.mtime),
           // use the same template engine as the non-variant
           engine: currentPattern.engine
         }, patternlab);
 
+        pattern_assembler.check_build_state(currentPattern, patternlab);
         //process the companion markdown file if it exists
         pattern_assembler.parse_pattern_markdown(patternVariant, patternlab);
 

--- a/test/pseudopattern_hunter_tests.js
+++ b/test/pseudopattern_hunter_tests.js
@@ -9,6 +9,7 @@ var fs = require('fs-extra');
 var pattern_assembler = new pa();
 var pseudopattern_hunter = new pha();
 var patterns_dir = './test/files/_patterns/';
+var public_patterns_dir = './test/public/patterns';
 
 function stubPatternlab() {
   var pl = {};
@@ -16,6 +17,9 @@ function stubPatternlab() {
     paths: {
       source: {
         patterns: patterns_dir
+      },
+      public: {
+        patterns: public_patterns_dir
       }
     }
   };
@@ -25,7 +29,7 @@ function stubPatternlab() {
   pl.patterns = [];
   pl.partials = {};
   pl.config.patternStates = {};
-  pl.config.outputFileSuffixes = { rendered: ''}
+  pl.config.outputFileSuffixes = { rendered: ''};
 
   return pl;
 }


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #540 

Summary of changes:
This is a prototype for recompiling any templates that have been modified since they have been previously built. This works by inspecting the source and output files' modification timestamps.
A pattern is marked as `needs rebuild` if any of its source files was modified after the modification timestamp of the output file. When the template was built and the output was written to disk, it is marked as `clean` to prevent building templates more than once.

### Working
A pattern is recompiled iif

- the template itself was modified
- its data (companion json) was modified
- it is a pseudo-pattern and the according json file was modified
- existing unit tests are running

### Not working yet

- [ ] Walking transitive dependencies for recompiling
- [ ] When using grunt, `patternlab:serve` will wipe the output folder.
- [ ] missing unit tests

### Won't do (for now)
When a JSON file is changed, currently this would trigger rebuilding all transitive templates. However this is a valid use case when it comes to data inheritance.