### PR TITLE
Hide "All" nav item if JSON flag is set

### DIFF
--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -545,7 +545,7 @@ var ui_builder = function () {
     output += 'var ishControls = {"ishControlsHide":' + JSON.stringify(patternlab.config.ishControlsHide) + '};' + eol;
 
     //navItems
-    output += 'var navItems = {"patternTypes": ' + JSON.stringify(patternlab.patternTypes) + '};' + eol;
+    output += 'var navItems = {"patternTypes": ' + JSON.stringify(patternlab.patternTypes) + ', "ishControlsHide": ' + JSON.stringify(patternlab.config.ishControlsHide) +'};' + eol;
 
     //patternPaths
     output += 'var patternPaths = ' + JSON.stringify(patternlab.patternPaths) + ';' + eol;


### PR DESCRIPTION
Combined with pattern-lab/styleguidekit-assets-default#53 , the existing JSON flag `ishControlsHide.views-all` can be respected (hiding the "All" nav item at the topmost level).

Summary of changes:

More specifically, this allows the nav template to access the hiding options set in the JSON `ishControlsHide` object. Previously this object was only accessible to the ish template.
