### PR TITLE
Expose the pattern engines as a property of the patternlab object

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -18,7 +18,8 @@ var diveSync = require('diveSync'),
   inherits = require('util').inherits,
   pm = require('./plugin_manager'),
   fs = require('fs-extra'),
-  plutils = require('./utilities');
+  plutils = require('./utilities'),
+  patternEngines = require('./pattern_engines');
 
 var EventEmitter = require('events').EventEmitter;
 
@@ -136,6 +137,8 @@ var patternlab_engine = function (config) {
     sm = require('./starterkit_manager'),
     Pattern = require('./object_factory').Pattern,
     patternlab = {};
+
+    patternlab.engines = patternEngines;
 
   var pattern_assembler = new pa(),
     pattern_exporter = new pe(),


### PR DESCRIPTION
When developing a patternlab-node plugin, I found it useful to have access to the loaded pattern engines as a property of the patternlab object.  This PR introduces an `engines` property to the `patternlab` object.