### PR TITLE
Features/incremental build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "builtin": true
+    "builtin": true,
+    "es6": true
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ patternlab.json
 Thumbs.db
 source/css/style.css.map
 .idea/
-public/patterns
+public
+!test/patterns/public/.gitkeep
+!test/patterns/testDependencyGraph.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ patternlab.json
 Thumbs.db
 source/css/style.css.map
 .idea/
-public
+public/patterns

--- a/core/lib/changes_hunter.js
+++ b/core/lib/changes_hunter.js
@@ -2,15 +2,29 @@
 const fs = require("fs-extra"),
   CompileState = require('./object_factory').CompileState;
 
-
-
-let changesHunter = function() {
+/**
+ * For detecting changed patterns.
+ * @constructor
+ */
+let ChangesHunter = function () {
 };
 
-changesHunter.prototype = {
+ChangesHunter.prototype = {
+
+  /**
+   * Checks the build state of a pattern by comparing the modification date of the rendered output
+   * file with the {@link Pattern.lastModified}. If the pattern was modified after the last
+   * time it has been rendered, it is flagged for rebuilding via {@link CompileState.NEEDS_REBUILD}.
+   *
+   * @param {Pattern} pattern
+   * @param patternlab
+   *
+   * @see {@link CompileState}
+   */
   checkBuildState: function (pattern, patternlab) {
+
     //write the compiled template to the public patterns directory
-    var renderedTemplatePath =
+    let renderedTemplatePath =
       patternlab.config.paths.public.patterns + pattern.getPatternLink(patternlab, 'rendered');
 
     if (!pattern.compileState) {
@@ -20,7 +34,7 @@ changesHunter.prototype = {
     try {
       // Prevent error message if file does not exist
       fs.accessSync(renderedTemplatePath, fs.F_OK);
-      var outputLastModified = fs.statSync(renderedTemplatePath).mtime.getTime();
+      let outputLastModified = fs.statSync(renderedTemplatePath).mtime.getTime();
 
       if (pattern.lastModified && outputLastModified > pattern.lastModified) {
         pattern.compileState = CompileState.CLEAN;
@@ -45,6 +59,7 @@ changesHunter.prototype = {
   /**
    * Updates {Pattern#lastModified} to the files modification date if the file was modified
    * after {Pattern#lastModified}.
+   *
    * @param {Pattern} currentPattern
    * @param {string} file
    */
@@ -52,6 +67,7 @@ changesHunter.prototype = {
     if (file) {
       try {
         let stat = fs.statSync(file);
+
         // Needs recompile whenever one of the patterns files (template, json, pseudopatterns) changed
         currentPattern.lastModified =
           Math.max(stat.mtime.getTime(), currentPattern.lastModified || 0);
@@ -62,4 +78,4 @@ changesHunter.prototype = {
   }
 };
 
-module.exports = changesHunter;
+module.exports = ChangesHunter;

--- a/core/lib/changes_hunter.js
+++ b/core/lib/changes_hunter.js
@@ -1,0 +1,65 @@
+"use strict";
+const fs = require("fs-extra"),
+  CompileState = require('./object_factory').CompileState;
+
+
+
+let changesHunter = function() {
+};
+
+changesHunter.prototype = {
+  checkBuildState: function (pattern, patternlab) {
+    //write the compiled template to the public patterns directory
+    var renderedTemplatePath =
+      patternlab.config.paths.public.patterns + pattern.getPatternLink(patternlab, 'rendered');
+
+    if (!pattern.compileState) {
+      pattern.compileState = CompileState.NEEDS_REBUILD;
+    }
+
+    try {
+      // Prevent error message if file does not exist
+      fs.accessSync(renderedTemplatePath, fs.F_OK);
+      var outputLastModified = fs.statSync(renderedTemplatePath).mtime.getTime();
+
+      if (pattern.lastModified && outputLastModified > pattern.lastModified) {
+        pattern.compileState = CompileState.CLEAN;
+      }
+    } catch (e) {
+      // Output does not exist yet, needs recompile
+    }
+
+    let node = patternlab.graph.node(pattern);
+
+    // Make the pattern known to the PatternGraph and remember its compileState
+    if (!node) {
+      patternlab.graph.add(pattern);
+    } else {
+      // Works via object reference, so we directly manipulate the node data here
+      node.compileState = pattern.compileState;
+    }
+
+
+  },
+
+  /**
+   * Updates {Pattern#lastModified} to the files modification date if the file was modified
+   * after {Pattern#lastModified}.
+   * @param {Pattern} currentPattern
+   * @param {string} file
+   */
+  checkLastModified: function (currentPattern, file) {
+    if (file) {
+      try {
+        let stat = fs.statSync(file);
+        // Needs recompile whenever one of the patterns files (template, json, pseudopatterns) changed
+        currentPattern.lastModified =
+          Math.max(stat.mtime.getTime(), currentPattern.lastModified || 0);
+      } catch (e) {
+        // Ignore, not a regular file
+      }
+    }
+  }
+};
+
+module.exports = changesHunter;

--- a/core/lib/lineage_hunter.js
+++ b/core/lib/lineage_hunter.js
@@ -7,6 +7,8 @@ var lineage_hunter = function () {
   var pa = require('./pattern_assembler');
 
   function findlineage(pattern, patternlab) {
+    // As we are adding edges from pattern to ancestor patterns, ensure it is known to the graph
+    patternlab.graph.add(pattern);
 
     var pattern_assembler = new pa();
 

--- a/core/lib/lineage_hunter.js
+++ b/core/lib/lineage_hunter.js
@@ -33,6 +33,7 @@ var lineage_hunter = function () {
           }
 
           patternlab.graph.add(ancestorPattern);
+
           // Confusing: pattern includes "ancestorPattern", not the other way round
           patternlab.graph.link(pattern, ancestorPattern);
 
@@ -70,10 +71,11 @@ var lineage_hunter = function () {
   function setPatternState(direction, pattern, targetPattern, graph) {
     var index = null;
     if (direction === 'fromPast') {
-      index  = graph.lineage(pattern);
+      index = graph.lineage(pattern);
     } else {
       index = graph.lineageR(pattern);
     }
+
     // if the request came from the past, apply target pattern state to current pattern lineage
     for (var i = 0; i < index.length; i++) {
       if (index[i].patternPartial === targetPattern.patternPartial) {

--- a/core/lib/lineage_hunter.js
+++ b/core/lib/lineage_hunter.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var extend = require("util")._extend;
+
 var lineage_hunter = function () {
 
   var pa = require('./pattern_assembler');
@@ -28,6 +30,10 @@ var lineage_hunter = function () {
             l.lineageState = ancestorPattern.patternState;
           }
 
+          patternlab.graph.add(ancestorPattern);
+          // Confusing: pattern includes "ancestorPattern", not the other way round
+          patternlab.graph.link(pattern, ancestorPattern);
+
           pattern.lineage.push(l);
 
           //also, add the lineageR entry if it doesn't exist
@@ -44,26 +50,32 @@ var lineage_hunter = function () {
             }
 
             ancestorPattern.lineageR.push(lr);
+            extend(patternlab.graph.node(ancestorPattern), lr);
           }
         }
       });
     }
   }
 
-  function setPatternState(direction, pattern, targetPattern) {
-    // if the request came from the past, apply target pattern state to current pattern lineage
+  /**
+   * Apply the target pattern state either to any predecessors or successors of the given
+   * pattern in the pattern graph.
+   * @param direction Either 'fromPast' or 'fromFuture'
+   * @param pattern {Pattern}
+   * @param targetPattern {Pattern}
+   * @param graph {PatternGraph}
+   */
+  function setPatternState(direction, pattern, targetPattern, graph) {
+    var index = null;
     if (direction === 'fromPast') {
-      for (var i = 0; i < pattern.lineageIndex.length; i++) {
-        if (pattern.lineageIndex[i] === targetPattern.patternPartial) {
-          pattern.lineage[i].lineageState = targetPattern.patternState;
-        }
-      }
+      index  = graph.lineage(pattern);
     } else {
-      //the request came from the future, apply target pattern state to current pattern reverse lineage
-      for (var i = 0; i < pattern.lineageRIndex.length; i++) {
-        if (pattern.lineageRIndex[i] === targetPattern.patternPartial) {
-          pattern.lineageR[i].lineageState = targetPattern.patternState;
-        }
+      index = graph.lineageR(pattern);
+    }
+    // if the request came from the past, apply target pattern state to current pattern lineage
+    for (var i = 0; i < index.length; i++) {
+      if (index[i].patternPartial === targetPattern.patternPartial) {
+        index[i].lineageState = targetPattern.patternState;
       }
     }
   }
@@ -71,35 +83,37 @@ var lineage_hunter = function () {
 
   function cascadePatternStates(patternlab) {
 
-    var pattern_assembler = new pa();
-
     for (var i = 0; i < patternlab.patterns.length; i++) {
       var pattern = patternlab.patterns[i];
 
       //for each pattern with a defined state
       if (pattern.patternState) {
+        var lineage = patternlab.graph.lineage(pattern);
 
-        if (pattern.lineageIndex && pattern.lineageIndex.length > 0) {
+        if (lineage && lineage.length > 0) {
 
           //find all lineage - patterns being consumed by this one
-          for (var h = 0; h < pattern.lineageIndex.length; h++) {
-            var lineagePattern = pattern_assembler.getPartial(pattern.lineageIndex[h], patternlab);
-            setPatternState('fromFuture', lineagePattern, pattern);
+          for (var h = 0; h < lineage.length; h++) {
+            // Not needed, the graph already knows the concrete pattern
+            // var lineagePattern = pattern_assembler.getPartial(lineageIndex[h], patternlab);
+            setPatternState('fromFuture', lineage[h], pattern, patternlab.graph);
           }
         }
-
-        if (pattern.lineageRIndex && pattern.lineageRIndex.length > 0) {
+        var lineageR = patternlab.graph.lineageR(pattern);
+        if (lineageR && lineageR.length > 0) {
 
           //find all reverse lineage - that is, patterns consuming this one
-          for (var j = 0; j < pattern.lineageRIndex.length; j++) {
+          for (var j = 0; j < lineageR.length; j++) {
 
-            var lineageRPattern = pattern_assembler.getPartial(pattern.lineageRIndex[j], patternlab);
+            var lineageRPattern = lineageR[j];
 
             //only set patternState if pattern.patternState "is less than" the lineageRPattern.patternstate
             //or if lineageRPattern.patternstate (the consuming pattern) does not have a state
             //this makes patternlab apply the lowest common ancestor denominator
-            if (lineageRPattern.patternState === '' || (patternlab.config.patternStateCascade.indexOf(pattern.patternState)
-              < patternlab.config.patternStateCascade.indexOf(lineageRPattern.patternState))) {
+            let patternStateCascade = patternlab.config.patternStateCascade;
+            let patternStateIndex = patternStateCascade.indexOf(pattern.patternState);
+            let patternReverseStateIndex = patternStateCascade.indexOf(lineageRPattern.patternState);
+            if (lineageRPattern.patternState === '' || (patternStateIndex < patternReverseStateIndex)) {
 
               if (patternlab.config.debug) {
                 console.log('Found a lower common denominator pattern state: ' + pattern.patternState + ' on ' + pattern.patternPartial + '. Setting reverse lineage pattern ' + lineageRPattern.patternPartial + ' from ' + (lineageRPattern.patternState === '' ? '<<blank>>' : lineageRPattern.patternState));
@@ -108,9 +122,9 @@ var lineage_hunter = function () {
               lineageRPattern.patternState = pattern.patternState;
 
               //take this opportunity to overwrite the lineageRPattern's lineage state too
-              setPatternState('fromPast', lineageRPattern, pattern);
+              setPatternState('fromPast', lineageRPattern, pattern, patternlab.graph);
             } else {
-              setPatternState('fromPast', pattern, lineageRPattern);
+              setPatternState('fromPast', pattern, lineageRPattern, patternlab.graph);
             }
           }
         }

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -73,6 +73,11 @@ var Pattern = function (relPath, data, patternlab) {
   this.isPseudoPattern = false;
   this.order = Number.MAX_SAFE_INTEGER;
   this.engine = patternEngines.getEngineForPattern(this);
+  // For completeness
+  this.compileState = null;
+  // The unix timestamp when the pattern was last modified
+  this.lastModified = null;
+
 };
 
 // Pattern methods
@@ -153,6 +158,13 @@ Pattern.create = function (relPath, data, customProps, patternlab) {
   return extend(newPattern, customProps);
 };
 
+var CompileState = {
+  NEEDS_REBUILD: "needs rebuild",
+  BUILDING: "building",
+  CLEAN: "clean"
+};
+
 module.exports = {
-  Pattern: Pattern
+  Pattern: Pattern,
+  CompileState: CompileState
 };

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -146,7 +146,16 @@ Pattern.prototype = {
 // factory: creates an empty Pattern for miscellaneous internal use, such as
 // by list_item_hunter
 Pattern.createEmpty = function (customProps, patternlab) {
-  var pattern = new Pattern('', null, patternlab);
+  let relPath = '';
+  if (customProps) {
+    if (customProps.relPath) {
+      relPath = customProps.relPath;
+    } else if (customProps.subdir && customProps.filename) {
+      relPath = customProps.subdir + path.sep + customProps.filename;
+    }
+  }
+
+  var pattern = new Pattern(relPath, null, patternlab);
   return extend(pattern, customProps);
 };
 

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -73,9 +73,19 @@ var Pattern = function (relPath, data, patternlab) {
   this.isPseudoPattern = false;
   this.order = Number.MAX_SAFE_INTEGER;
   this.engine = patternEngines.getEngineForPattern(this);
-  // For completeness
+
+  /**
+   * Determines if this pattern needs to be recompiled.
+   *
+   * @ee {@link CompileState}*/
   this.compileState = null;
-  // The unix timestamp when the pattern was last modified
+
+  /**
+   * Timestamp in milliseconds when the pattern template or auxilary file (e.g. json) were modified.
+   * If multiple files are affected, this is the timestamp of the most recent change.
+   *
+   * @see {@link pattern}
+   */
   this.lastModified = null;
 
 };

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -369,7 +369,7 @@ var pattern_assembler = function () {
     currentPattern.parameteredPartials = currentPattern.findPartialsWithPatternParameters();
 
     [templatePath, jsonFilename, listJsonFileName].forEach(file => {
-      changes_hunter.checkLastModified(currentPattern, file)
+      changes_hunter.checkLastModified(currentPattern, file);
     });
 
     changes_hunter.checkBuildState(currentPattern, patternlab);
@@ -405,7 +405,7 @@ var pattern_assembler = function () {
   }
 
   function findModifiedPatterns(lastModified, patternlab) {
-    return patternlab.patterns.filter( p => {
+    return patternlab.patterns.filter(p => {
       if (p.compileState !== CompileState.CLEAN || ! p.lastModified) {
         return true;
       }
@@ -527,7 +527,7 @@ var pattern_assembler = function () {
 
   return {
     find_modified_patterns: function (lastModified, patternlab) {
-      return findModifiedPatterns(lastModified, patternlab)
+      return findModifiedPatterns(lastModified, patternlab);
     },
     find_pattern_partials: function (pattern) {
       return pattern.findPartials();

--- a/core/lib/pattern_graph.js
+++ b/core/lib/pattern_graph.js
@@ -119,7 +119,6 @@ PatternGraph.prototype = {
         compileGraph.setNode(patternNode);
       }
       this.applyReverse(pattern, (from, to) => {
-        // FIXME to.compileState == null for pseudopatterns!
         from.compileState = CompileState.NEEDS_REBUILD;
         let fromName = nodeName(from);
         let toName = nodeName(to);

--- a/core/lib/pattern_graph.js
+++ b/core/lib/pattern_graph.js
@@ -1,0 +1,274 @@
+"use strict";
+
+var graphlib = require('graphlib');
+var Graph = graphlib.Graph;
+var path = require('path');
+var fs = require("fs-extra");
+var Pattern = require('./object_factory').Pattern;
+var CompileState = require('./object_factory').CompileState;
+var PatternGraphDot = require('./pattern_graph_dot');
+var PatternRegistry = require('./pattern_registry');
+
+/**
+ * Wrapper around a graph library to build a dependency graph of patterns and
+ *
+ * @param graph {Graph} The graphlib graph object
+ * @param timestamp {int} The unix timestamp
+ * @param registry {PatternRegistry} Central registry for patterns.
+ * @returns {{PatternGraph: PatternGraph}}
+ * @constructor Constructs a new PatternGraph from a JSON-style JavaScript object or an empty graph
+ * if no argument is given.
+ * @see PatternGraph#fromJson
+ * @see <a href="https://github.com/pattern-lab/patternlab-node/issues/540">#540</a>
+ */
+var PatternGraph = function (graph, timestamp) {
+
+  this.graph = graph || new Graph({
+    directed: true
+  });
+  this.graph.setDefaultEdgeLabel({});
+
+  // Allows faster lookups for patterns by name for each element in the graph
+  // The idea here is to make a pattern known to the graph as soon as it exists
+  this.patterns = new PatternRegistry();
+  this.timestamp = timestamp || new Date().getTime();
+};
+
+// shorthand. Use relPath as it is always unique, even with subPatternType
+var nodeName =
+  p => p instanceof Pattern ? p.relPath : p;
+
+PatternGraph.prototype = {
+  /**
+   * Creates an independent copy of the graph where nodes and edges can be modified without
+   * affecting the source.
+   * @param g {PatternGraph}
+   */
+  clone: function () {
+    var json = graphlib.json.write(this.graph);
+    var graph = graphlib.json.read(json);
+    return new PatternGraph(graph, this.timestamp);
+  },
+
+  /**
+   *
+   * @param pattern {Pattern}
+   */
+  add: function (pattern) {
+    var n = nodeName(pattern);
+    if (!this.patterns.has(n)) {
+      this.graph.setNode(n, {
+        compileState: pattern.compileState
+      });
+
+      // TODO events in pattern registry should call add(), instead of having this glue code.
+      this.patterns.put(pattern);
+    }
+  },
+
+  remove: function (pattern) {
+    var n = nodeName(pattern);
+    this.graph.removeNode(n);
+    this.patterns.remove(n);
+  },
+
+  /**
+   * Removes nodes for which the given predicate function returns false.
+   * @param fn {function} which takes a node name as argument
+   */
+  filter: function (fn) {
+    this.graph.nodes().forEach(n => {
+      if (!fn(n)) {
+        this.remove(n);
+      }
+    });
+  },
+
+  link: function (patternFrom, patternTo) {
+    this.add(patternFrom);
+    this.add(patternTo);
+
+    let nameFrom = nodeName(patternFrom);
+    let nameTo = nodeName(patternTo);
+    this.graph.setEdge(nameFrom, nameTo);
+  },
+
+
+  hasLink: function (patternFrom, patternTo) {
+    let nameFrom = nodeName(patternFrom);
+    let nameTo = nodeName(patternTo);
+    return this.graph.hasEdge(nameFrom, nameTo);
+  },
+
+  compileOrder: function () {
+    var compileStateFilter = function (patterns, n) {
+      var node = patterns.get(n);
+      return node.compileState !== CompileState.CLEAN;
+    };
+    // A graph with reversed edges for topological ordering
+    let compileGraph = new Graph({
+      directed: true
+    });
+
+    let changedNodes = this.graph.nodes().filter(n => compileStateFilter(this.patterns, n));
+    this.nodes2patterns(changedNodes).forEach(pattern => {
+      let patternNode = nodeName(pattern);
+      if (!compileGraph.hasNode(patternNode)) {
+        compileGraph.setNode(patternNode);
+      }
+      this.applyReverse(pattern, (from, to) => {
+        // FIXME to.compileState == null for pseudopatterns!
+        from.compileState = CompileState.NEEDS_REBUILD;
+        let fromName = nodeName(from);
+        let toName = nodeName(to);
+        for (let nodeName of [fromName, toName]) {
+          if (!compileGraph.hasNode(nodeName)) {
+            compileGraph.setNode(nodeName);
+          }
+        }
+        if (!compileGraph.hasNode(toName)) {
+          compileGraph.setNode(toName);
+        }
+        // reverse!
+        compileGraph.setEdge({v:toName, w:fromName});
+      });
+    });
+    // Apply topological sorting, Start at the leafs of the graphs (e.g. atoms) and go further
+    // up in the hierarchy
+    var o = graphlib.alg.topsort(compileGraph);
+    return this.nodes2patterns(o);
+  },
+
+  /**
+   * Given a node and its predecessor, allows exchanging states between nodes.
+   * @param pattern
+   * @param fn A function that takes the currently viewed pattern and node data. Allows synching data
+   * between patterns and node metadata.
+   */
+  applyReverse: function (pattern, fn) {
+    for (let p of this.lineageR(pattern)) {
+      fn(p, pattern);
+      this.applyReverse(p, fn);
+    }
+  },
+
+  node: function (pattern) {
+    return this.graph.node(nodeName(pattern));
+  },
+
+  /**
+   *
+   * @param nodes {Array}
+   * @return {Array} An Array of Patterns
+   */
+  nodes2patterns: function (nodes) {
+    return nodes.map(n => this.patterns.get(n));
+  },
+
+  // TODO cache result in a Map[String, Array]?
+  // We trade the pattern.lineage array - O(pattern.lineage.length << |V|) - vs. O(|V|) of the graph.
+  // As long as no edges are added or removed, we can cache the result in a Map and just return it.
+  lineage: function (pattern) {
+    var nodes = this.graph.successors(nodeName(pattern));
+    return this.nodes2patterns(nodes);
+  },
+
+  /**
+   * Returns all patterns that include the given pattern
+   * @param pattern {Pattern}
+   * @return {*|Array}
+   */
+  lineageR: function (pattern) {
+    var nodes = this.graph.predecessors(nodeName(pattern));
+    return this.nodes2patterns(nodes);
+  },
+
+  /**
+   * Given a {Pattern}, return all {Pattern} objects included in this the given pattern
+   * @param pattern
+   */
+  lineageIndex: function (pattern) {
+    var lineage = this.lineage(pattern);
+    return lineage.map(p => p.patternPartial);
+  },
+
+  /**
+   * Given a {Pattern}, return all {Pattern} objects which include the given pattern
+   * @param pattern
+   */
+  lineageRIndex: function (pattern) {
+    var lineageR = this.lineageR(pattern);
+    return lineageR.map(p => p.patternPartial);
+  },
+
+  /**
+   *
+   * @returns {{timestamp: number, graph}}
+   */
+  toJson: function () {
+    return {
+      timestamp: this.timestamp,
+      graph: graphlib.json.write(this.graph)
+    };
+  },
+
+  nodes: function () {
+    return this.graph.nodes();
+  }
+};
+
+/**
+ * @return {PatternGraph}
+ */
+PatternGraph.empty = function () {
+  return new PatternGraph(null, 0);
+};
+
+/**
+ * Parse the graph from a JSON object.
+ * @param o The JSON object to read from
+ */
+PatternGraph.fromJson = function (o) {
+  var graph = graphlib.json.read(o.graph);
+  return new PatternGraph(graph, o.timestamp);
+};
+
+PatternGraph.resolveJsonGraphFile = function (patternlab, file) {
+  return path.resolve(patternlab.config.paths.public.root, file || 'dependencyGraph.json');
+};
+
+/**
+ * Loads a graph from the file. Does not add any patterns from the patternlab object,
+ * i.e. graph.patterns will be still empty until all patterns have been processed.
+ *
+ * @param patternlab
+ * @param [file] Optional
+ */
+PatternGraph.loadFromFile = function (patternlab, file) {
+  var jsonGraphFile = this.resolveJsonGraphFile(patternlab, file);
+
+  // File is fresh, so simply constuct an empty graph in memory
+  if (!fs.existsSync(jsonGraphFile)) {
+    return PatternGraph.empty();
+  }
+
+  var obj = fs.readJSONSync(jsonGraphFile);
+  return this.fromJson(obj);
+};
+
+// Second argument is for unit testing only
+PatternGraph.storeToFile = function (patternlab, file) {
+  var jsonGraphFile = this.resolveJsonGraphFile(patternlab, file);
+  patternlab.graph.timestamp = new Date().getTime();
+  fs.writeJSONSync(jsonGraphFile, patternlab.graph.toJson());
+};
+
+PatternGraph.exportToDot = function (patternlab, file) {
+  var dotFile = this.resolveJsonGraphFile(patternlab, file);
+  var g = PatternGraphDot.write(patternlab.graph);
+  fs.outputFileSync(dotFile, g);
+};
+
+module.exports = {
+  PatternGraph: PatternGraph
+};

--- a/core/lib/pattern_graph.js
+++ b/core/lib/pattern_graph.js
@@ -311,7 +311,7 @@ PatternGraph.empty = function (version) {
  * @param {PatternGraph|Object} graphOrJson
  * @return {boolean}
  */
-PatternGraph.checkVersion = function(graphOrJson) {
+PatternGraph.checkVersion = function (graphOrJson) {
   return graphOrJson.version === PATTERN_GRAPH_VERSION;
 };
 
@@ -369,7 +369,7 @@ PatternGraph.loadFromFile = function (patternlab, file) {
 
   const obj = fs.readJSONSync(jsonGraphFile);
   if (!PatternGraph.checkVersion(obj)) {
-    return PatternGraph.empty(obj.version)
+    return PatternGraph.empty(obj.version);
   }
   return this.fromJson(obj);
 };

--- a/core/lib/pattern_graph.js
+++ b/core/lib/pattern_graph.js
@@ -85,11 +85,12 @@ PatternGraph.prototype = {
   },
 
   link: function (patternFrom, patternTo) {
-    this.add(patternFrom);
-    this.add(patternTo);
-
     let nameFrom = nodeName(patternFrom);
     let nameTo = nodeName(patternTo);
+    for (let name of [nameFrom, nameTo])
+    if (!this.patterns.has(name)) {
+      throw new Error("Pattern not known: " + name);
+    }
     this.graph.setEdge(nameFrom, nameTo);
   },
 
@@ -110,7 +111,8 @@ PatternGraph.prototype = {
       directed: true
     });
 
-    let changedNodes = this.graph.nodes().filter(n => compileStateFilter(this.patterns, n));
+    let nodes = this.graph.nodes();
+    let changedNodes = nodes.filter(n => compileStateFilter(this.patterns, n));
     this.nodes2patterns(changedNodes).forEach(pattern => {
       let patternNode = nodeName(pattern);
       if (!compileGraph.hasNode(patternNode)) {

--- a/core/lib/pattern_graph_dot.js
+++ b/core/lib/pattern_graph_dot.js
@@ -70,7 +70,7 @@ PatternGraphDot.write = function (patternGraph) {
   var colors = ["darkgreen", "firebrick", "slateblue", "darkgoldenrod", "black"];
   var colorMap = new Map();
   var colIdx = 0;
-  for (let p of patterns.values()) {
+  for (let p of patterns.partials.values()) {
     if (p.isPseudoPattern || !p.patternType) {
       continue;
     }

--- a/core/lib/pattern_graph_dot.js
+++ b/core/lib/pattern_graph_dot.js
@@ -1,0 +1,137 @@
+"use strict";
+var graphlib = require('graphlib');
+var path = require('path');
+var fs = require("fs-extra");
+
+function header() {
+  return [
+  "strict digraph {",
+    'graph [fontname = "helvetica" size=20]',
+    /*compound=true;*/
+     "concentrate=true;",
+    "rankdir=LR;",
+    "ranksep=\"4 equally·\";",
+    "node [style=filled,color=white];",
+    "edge [style=dotted constraint=false]"
+  ];
+}
+
+var niceKey = function (s) {
+  return "O" + s.replace("-", "");
+};
+
+function subgraph(group, patterns, color) {
+  var s = niceKey(group);
+  return [
+    "subgraph cluster_X" + s + " {",
+    "label=<<b>" + group + "</b>>;",
+    "style=filled;",
+    "color=lightgrey;",
+    s + " [shape=box];",
+    patterns.map(addNode).join(""),
+    //patterns.map(p => "\"" + p.name + "\"").join(" -> ") + "[style=invis]",
+    "}"
+    ];
+
+}
+
+function footer() {
+  return ["}"];
+}
+
+  /**
+   *
+   * @param pattern {Pattern}
+   * @return {string}
+   */
+function addNode(pattern) {
+  let more = "";
+  if (pattern.isPseudoPattern) {
+    more = " [fillcolor=grey]"
+  }
+  return "\"" + pattern.name + "\"" + more + ";\n";
+}
+
+  /**
+   *
+   * @param from {Pattern}
+   * @param to {Pattern}
+   * @return {string}
+   */
+function addEdge (from, to, color) {
+  return "\"" + from.name + "\" -> " +  "\"" + to.name + "\" [color=" + color + "];\n";
+}
+
+var PatternGraphDot = {};
+PatternGraphDot.write = function (patternGraph) {
+  var g = patternGraph.graph;
+  var patterns = patternGraph.patterns;
+  let buckets = new Map();
+  var colors = ["darkgreen", "firebrick", "slateblue", "darkgoldenrod", "black"];
+  var colorMap = new Map();
+  var colIdx = 0;
+  for (let p of patterns.values()) {
+    if (p.isPseudoPattern || !p.patternType) {
+      continue;
+    }
+    let bucket = buckets.get(p.patternType);
+    if (bucket) {
+      bucket.push(p)
+    } else {
+      bucket = [p];
+      colorMap.set(p.patternType, colors[colIdx++]);
+      // Repeat if there are more categories
+      colIdx = colIdx % colors.length;
+    }
+    buckets.set(p.patternType, bucket);
+  }
+
+  /*
+
+
+   edge[style=\"\", fontsize=12];
+
+   { rank=same;
+   0 [style = \"\"];
+   01 [style = \"\"];
+   02 [style=\"\"];
+   0 -> 01 -> 02;
+   }
+   0 -> "0A"[style=solid];
+   01 -> "0B"[style=invis];
+   02 -> "0C"[style=invis];
+   */
+  var res = header();
+  var sortedKeys = Array.from(buckets.keys()).sort();
+
+  var niceKeys = sortedKeys.map(niceKey);
+
+  var subgraphLines = [];
+
+
+  for (let key of sortedKeys) {
+    var subpatterns = buckets.get(key);
+    subgraphLines = subgraphLines.concat(subgraph(key, subpatterns));
+  }
+  res = res.concat(subgraphLines);
+  res.push("edge[style=solid];");
+
+
+  foo: for (let e of g.edges()) {
+    let vw = patternGraph.nodes2patterns([e.v, e.w]);
+    for (let p of vw) {
+      if (p.isPseudoPattern || !p.patternType) {
+        continue foo;
+      }
+    }
+    var thisColor = colorMap.get(vw[0].patternType);
+    res.push(addEdge(vw[0], vw[1], thisColor));
+  }
+
+  res.push(niceKeys.reverse().join(" -> ") + "[constraint=true];");
+  res = res.concat(footer());
+  return res.join("\n") + "\n";
+};
+
+
+module.exports = PatternGraphDot;

--- a/core/lib/pattern_registry.js
+++ b/core/lib/pattern_registry.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Allows lookups for patterns via a central registry.
+ * @constructor
+ */
+// Future idea:
+var PatternRegistry = function() {
+  this.key2pattern = new Map();
+  /** For lookups by {Pattern#partialKey} */
+  this.partials = new Map();
+};
+
+//noinspection JSUnusedLocalSymbols
+PatternRegistry.prototype = {
+
+  allPatterns: function() {
+    return Array.from(this.key2pattern.values())
+  },
+
+  has: function(name) {
+    return this.key2pattern.has(name);
+  },
+
+  get: function(name) {
+    return this.key2pattern.get(name);
+  },
+
+  /**
+   * Adds the given pattern to the registry. If a pattern with the same key exists, it is replaced.
+   * @param pattern {Pattern|*}
+   */
+  put: function (pattern) {
+    var name = PatternRegistry.partialName(pattern);
+    this.partials.set(name, pattern);
+    var key = PatternRegistry.patternKey(pattern);
+    this.key2pattern.set(key, pattern);
+  },
+
+  remove: function (name) {
+    this.key2pattern.delete(name);
+  },
+
+  getPartial: function (partialName) {
+    /*
+     Code in here has been moved from pattern_assembler.getPartial() to prepare for some refactoring.
+     There are a few advantages to this method:
+     - use a map lookup instead of interating through all patterns
+     - get rid of dependency to the patternlab object
+     - make code more readable
+     */
+
+    // This previously has been a for loop over an array in pattern_
+    let byPartialName = this.partials.get(partialName);
+    if (this.partials.has(partialName)) {
+      return byPartialName;
+    }
+
+
+    let patterns = this.allPatterns();
+    //else look by verbose syntax
+    for (let thisPattern of patterns) {
+      switch (partialName) {
+        case thisPattern.relPath:
+        case thisPattern.subdir + '/' + thisPattern.fileName:
+          return thisPattern;
+      }
+    }
+
+    //return the fuzzy match if all else fails
+    for (let thisPattern of patterns) {
+      var partialParts = partialName.split('-'),
+        partialType = partialParts[0],
+        partialNameEnd = partialParts.slice(1).join('-');
+
+      var patternPartial = thisPattern.patternPartial;
+      if (patternPartial.split('-')[0] === partialType
+        && patternPartial.indexOf(partialNameEnd) > -1) {
+        return thisPattern;
+      }
+    }
+    return undefined;
+  }
+};
+
+PatternRegistry.patternKey = function (pattern) {
+  return pattern.relPath;
+};
+
+/**
+ * Defines how the partial key of a pattern is resolved.
+ *
+ * @param pattern {Pattern}
+ * @return {string}
+ */
+PatternRegistry.partialName = function (pattern) {
+  return pattern.patternPartial;
+};
+
+module.exports = PatternRegistry;

--- a/core/lib/pattern_registry.js
+++ b/core/lib/pattern_registry.js
@@ -4,25 +4,24 @@
  * Allows lookups for patterns via a central registry.
  * @constructor
  */
-// Future idea:
-var PatternRegistry = function() {
+const PatternRegistry = function () {
   this.key2pattern = new Map();
-  /** For lookups by {Pattern#partialKey} */
+
+  /** For lookups by {@link Pattern#partialKey} */
   this.partials = new Map();
 };
 
-//noinspection JSUnusedLocalSymbols
 PatternRegistry.prototype = {
 
-  allPatterns: function() {
-    return Array.from(this.key2pattern.values())
+  allPatterns: function () {
+    return Array.from(this.key2pattern.values());
   },
 
-  has: function(name) {
+  has: function (name) {
     return this.key2pattern.has(name);
   },
 
-  get: function(name) {
+  get: function (name) {
     return this.key2pattern.get(name);
   },
 
@@ -31,9 +30,9 @@ PatternRegistry.prototype = {
    * @param pattern {Pattern|*}
    */
   put: function (pattern) {
-    var name = PatternRegistry.partialName(pattern);
+    const name = PatternRegistry.partialName(pattern);
     this.partials.set(name, pattern);
-    var key = PatternRegistry.patternKey(pattern);
+    const key = PatternRegistry.patternKey(pattern);
     this.key2pattern.set(key, pattern);
   },
 
@@ -58,6 +57,7 @@ PatternRegistry.prototype = {
 
 
     let patterns = this.allPatterns();
+
     //else look by verbose syntax
     for (let thisPattern of patterns) {
       switch (partialName) {
@@ -69,11 +69,11 @@ PatternRegistry.prototype = {
 
     //return the fuzzy match if all else fails
     for (let thisPattern of patterns) {
-      var partialParts = partialName.split('-'),
+      const partialParts = partialName.split('-'),
         partialType = partialParts[0],
         partialNameEnd = partialParts.slice(1).join('-');
 
-      var patternPartial = thisPattern.patternPartial;
+      const patternPartial = thisPattern.patternPartial;
       if (patternPartial.split('-')[0] === partialType
         && patternPartial.indexOf(partialNameEnd) > -1) {
         return thisPattern;

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -13,7 +13,6 @@
 var diveSync = require('diveSync'),
   glob = require('glob'),
   _ = require('lodash'),
-  fs = require('fs-extra'),
   path = require('path'),
   chalk = require('chalk'),
   cleanHtml = require('js-beautify').html,
@@ -164,6 +163,7 @@ var patternlab_engine = function (config) {
   patternlab.package = fs.readJSONSync(path.resolve(__dirname, '../../package.json'));
   patternlab.config = config || fs.readJSONSync(path.resolve(__dirname, '../../patternlab-config.json'));
   patternlab.events = new PatternLabEventEmitter();
+
   // Initialized when building
   patternlab.graph = null;
 
@@ -343,6 +343,101 @@ var patternlab_engine = function (config) {
     outputFiles.forEach(outFile => fs.outputFileSync(outFile.path, outFile.content));
   }
 
+  function renderSinglePattern(pattern, head) {
+    // Pattern does not need to be built and recompiled more than once
+    if (!pattern.isPattern || pattern.compileState === CompileState.CLEAN) {
+      return false;
+    }
+
+    // Allows serializing the compile state
+    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.BUILDING;
+
+    //todo move this into lineage_hunter
+    pattern.patternLineages = pattern.lineage;
+    pattern.patternLineageExists = pattern.lineage.length > 0;
+    pattern.patternLineagesR = pattern.lineageR;
+    pattern.patternLineageRExists = pattern.lineageR.length > 0;
+    pattern.patternLineageEExists = pattern.patternLineageExists || pattern.patternLineageRExists;
+
+    patternlab.events.emit('patternlab-pattern-before-data-merge', patternlab, pattern);
+
+    //render the pattern, but first consolidate any data we may have
+    var allData;
+    try {
+      allData = JSON5.parse(JSON5.stringify(patternlab.data));
+    } catch (err) {
+      console.log('There was an error parsing JSON for ' + pattern.relPath);
+      console.log(err);
+    }
+    allData = plutils.mergeData(allData, pattern.jsonFileData);
+    allData.cacheBuster = patternlab.cacheBuster;
+
+    //re-rendering the headHTML each time allows pattern-specific data to influence the head of the pattern
+    pattern.header = head;
+    var headHTML = pattern_assembler.renderPattern(pattern.header, allData);
+
+    //render the extendedTemplate with all data
+    pattern.patternPartialCode = pattern_assembler.renderPattern(pattern, allData);
+
+    // stringify this data for individual pattern rendering and use on the styleguide
+    // see if patternData really needs these other duped values
+    pattern.patternData = JSON.stringify({
+      cssEnabled: false,
+      patternLineageExists: pattern.patternLineageExists,
+      patternLineages: pattern.patternLineages,
+      lineage: pattern.patternLineages,
+      patternLineageRExists: pattern.patternLineageRExists,
+      patternLineagesR: pattern.patternLineagesR,
+      lineageR: pattern.patternLineagesR,
+      patternLineageEExists: pattern.patternLineageExists || pattern.patternLineageRExists,
+      patternDesc: pattern.patternDescExists ? pattern.patternDesc : '',
+      patternBreadcrumb:
+        pattern.patternGroup === pattern.patternSubGroup ? {
+          patternType: pattern.patternGroup
+        } : {
+          patternType: pattern.patternGroup,
+          patternSubtype: pattern.patternSubGroup
+        },
+      patternExtension: pattern.fileExtension.substr(1), //remove the dot because styleguide asset default adds it for us
+      patternName: pattern.patternName,
+      patternPartial: pattern.patternPartial,
+      patternState: pattern.patternState,
+      patternEngineName: pattern.engine.engineName,
+      extraOutput: {}
+    });
+
+    //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
+    var footerPartial = pattern_assembler.renderPattern(patternlab.footer, {
+      isPattern: pattern.isPattern,
+      patternData: pattern.patternData,
+      cacheBuster: patternlab.cacheBuster
+    });
+
+    var allFooterData;
+    try {
+      allFooterData = JSON5.parse(JSON5.stringify(patternlab.data));
+    } catch (err) {
+      console.log('There was an error parsing JSON for ' + pattern.relPath);
+      console.log(err);
+    }
+    allFooterData = plutils.mergeData(allFooterData, pattern.jsonFileData);
+    allFooterData.patternLabFoot = footerPartial;
+
+    var footerHTML = pattern_assembler.renderPattern(patternlab.userFoot, allFooterData);
+
+    patternlab.events.emit('patternlab-pattern-write-begin', patternlab, pattern);
+
+    //write the compiled template to the public patterns directory
+    writePatternFiles(headHTML, pattern, footerHTML);
+
+    patternlab.events.emit('patternlab-pattern-write-end', patternlab, pattern);
+
+    // Allows serializing the compile state
+    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.CLEAN;
+    plutils.log.info("Built pattern: " + pattern.patternPartial);
+    return true;
+  }
+
   function buildPatterns(deletePatternDir) {
 
     patternlab.events.emit('patternlab-build-pattern-start', patternlab);
@@ -426,6 +521,7 @@ var patternlab_engine = function (config) {
       // TODO Find created or deleted files
       let now = new Date().getTime();
       var modified = pattern_assembler.find_modified_patterns(now, patternlab);
+
       // First mark all modified files
       for (let p of modified) {
         p.compileState = CompileState.NEEDS_REBUILD;
@@ -436,105 +532,13 @@ var patternlab_engine = function (config) {
 
     //render all patterns last, so lineageR works
     patternsToBuild.forEach(pattern => renderSinglePattern(pattern, head));
+
     // Saves the pattern graph when all files have been compiled
     PatternGraph.storeToFile(patternlab);
     PatternGraph.exportToDot(patternlab, "dependencyGraph.dot");
+
     //export patterns if necessary
     pattern_exporter.export_patterns(patternlab);
-  }
-
-  function renderSinglePattern(pattern, head) {
-    // Pattern does not need to be built and recompiled more than once
-    if (!pattern.isPattern || pattern.compileState === CompileState.CLEAN) {
-      return false;
-    }
-    // Allows serializing the compile state
-    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.BUILDING;
-
-    //todo move this into lineage_hunter
-    pattern.patternLineages = pattern.lineage;
-    pattern.patternLineageExists = pattern.lineage.length > 0;
-    pattern.patternLineagesR = pattern.lineageR;
-    pattern.patternLineageRExists = pattern.lineageR.length > 0;
-    pattern.patternLineageEExists = pattern.patternLineageExists || pattern.patternLineageRExists;
-
-    patternlab.events.emit('patternlab-pattern-before-data-merge', patternlab, pattern);
-
-    //render the pattern, but first consolidate any data we may have
-    var allData;
-    try {
-      allData = JSON5.parse(JSON5.stringify(patternlab.data));
-    } catch (err) {
-      console.log('There was an error parsing JSON for ' + pattern.relPath);
-      console.log(err);
-    }
-    allData = plutils.mergeData(allData, pattern.jsonFileData);
-    allData.cacheBuster = patternlab.cacheBuster;
-
-    //re-rendering the headHTML each time allows pattern-specific data to influence the head of the pattern
-    pattern.header = head;
-    var headHTML = pattern_assembler.renderPattern(pattern.header, allData);
-
-    //render the extendedTemplate with all data
-    pattern.patternPartialCode = pattern_assembler.renderPattern(pattern, allData);
-
-    // stringify this data for individual pattern rendering and use on the styleguide
-    // see if patternData really needs these other duped values
-    pattern.patternData = JSON.stringify({
-      cssEnabled: false,
-      patternLineageExists: pattern.patternLineageExists,
-      patternLineages: pattern.patternLineages,
-      lineage: pattern.patternLineages,
-      patternLineageRExists: pattern.patternLineageRExists,
-      patternLineagesR: pattern.patternLineagesR,
-      lineageR: pattern.patternLineagesR,
-      patternLineageEExists: pattern.patternLineageExists || pattern.patternLineageRExists,
-      patternDesc: pattern.patternDescExists ? pattern.patternDesc : '',
-      patternBreadcrumb:
-        pattern.patternGroup === pattern.patternSubGroup ?
-        {
-          patternType: pattern.patternGroup
-        } : {
-          patternType: pattern.patternGroup,
-          patternSubtype: pattern.patternSubGroup
-        },
-      patternExtension: pattern.fileExtension.substr(1), //remove the dot because styleguide asset default adds it for us
-      patternName: pattern.patternName,
-      patternPartial: pattern.patternPartial,
-      patternState: pattern.patternState,
-      patternEngineName: pattern.engine.engineName,
-      extraOutput: {}
-    });
-
-    //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
-    var footerPartial = pattern_assembler.renderPattern(patternlab.footer, {
-      isPattern: pattern.isPattern,
-      patternData: pattern.patternData,
-      cacheBuster: patternlab.cacheBuster
-    });
-
-    var allFooterData;
-    try {
-      allFooterData = JSON5.parse(JSON5.stringify(patternlab.data));
-    } catch (err) {
-      console.log('There was an error parsing JSON for ' + pattern.relPath);
-      console.log(err);
-    }
-    allFooterData = plutils.mergeData(allFooterData, pattern.jsonFileData);
-    allFooterData.patternLabFoot = footerPartial;
-
-    var footerHTML = pattern_assembler.renderPattern(patternlab.userFoot, allFooterData);
-
-    patternlab.events.emit('patternlab-pattern-write-begin', patternlab, pattern);
-
-    //write the compiled template to the public patterns directory
-    writePatternFiles(headHTML, pattern, footerHTML);
-
-    patternlab.events.emit('patternlab-pattern-write-end', patternlab, pattern);
-    // Allows serializing the compile state
-    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.CLEAN;
-    plutils.log.info("Built pattern: " + pattern.patternPartial);
-    return true;
   }
 
   return {

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -544,7 +544,10 @@ var patternlab_engine = function (config) {
 
     // Saves the pattern graph when all files have been compiled
     PatternGraph.storeToFile(patternlab);
-    PatternGraph.exportToDot(patternlab, "dependencyGraph.dot");
+    if (patternlab.config.exportToGraphViz) {
+      PatternGraph.exportToDot(patternlab, "dependencyGraph.dot");
+      plutils.log.info(`Exported pattern graph to ${path.join(config.paths.public.root, "dependencyGraph.dot")}`);
+    }
 
     //export patterns if necessary
     pattern_exporter.export_patterns(patternlab);

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -435,7 +435,7 @@ var patternlab_engine = function (config) {
 
 
     //render all patterns last, so lineageR works
-    patternsToBuild.forEach( pattern => renderSinglePattern(pattern, head));
+    patternsToBuild.forEach(pattern => renderSinglePattern(pattern, head));
     // Saves the pattern graph when all files have been compiled
     PatternGraph.storeToFile(patternlab);
     PatternGraph.exportToDot(patternlab, "dependencyGraph.dot");
@@ -533,6 +533,7 @@ var patternlab_engine = function (config) {
     patternlab.events.emit('patternlab-pattern-write-end', patternlab, pattern);
     // Allows serializing the compile state
     patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.CLEAN;
+    plutils.log.info("Built pattern: " + pattern.patternPartial);
     return true;
   }
 

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -513,8 +513,17 @@ var patternlab_engine = function (config) {
 
     let patternsToBuild = patternlab.patterns;
 
+    let graphNeedsUpgrade = !PatternGraph.checkVersion(patternlab.graph);
+    // Incremental builds are enabled, but we cannot use them
+    if (!deletePatternDir && graphNeedsUpgrade) {
+      plutils.log.info("Due to an upgrade, a complete rebuild is required. " +
+        "Incremental build is available again on the next run.");
+      // Ensure that the freshly built graph has the latest version again.
+      patternlab.graph.upgradeVersion();
+    }
     //delete the contents of config.patterns.public before writing
-    if (deletePatternDir) {
+    //Also if the serialized graph must be updated
+    if (deletePatternDir || graphNeedsUpgrade) {
       fs.removeSync(paths.public.patterns);
       fs.emptyDirSync(paths.public.patterns);
     } else {

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -13,6 +13,7 @@
 var diveSync = require('diveSync'),
   glob = require('glob'),
   _ = require('lodash'),
+  fs = require('fs-extra'),
   path = require('path'),
   chalk = require('chalk'),
   cleanHtml = require('js-beautify').html,
@@ -20,7 +21,8 @@ var diveSync = require('diveSync'),
   pm = require('./plugin_manager'),
   fs = require('fs-extra'),
   packageInfo = require('../../package.json'),
-  plutils = require('./utilities');
+  plutils = require('./utilities'),
+  PatternGraph = require('./pattern_graph').PatternGraph;
 
 //register our log events
 plutils.log.on('error', msg => console.log(msg));
@@ -150,6 +152,7 @@ var patternlab_engine = function (config) {
     ui = require('./ui_builder'),
     sm = require('./starterkit_manager'),
     Pattern = require('./object_factory').Pattern,
+    CompileState = require('./object_factory').CompileState,
     patternlab = {};
 
   patternlab.engines = patternEngines;
@@ -161,9 +164,12 @@ var patternlab_engine = function (config) {
   patternlab.package = fs.readJSONSync(path.resolve(__dirname, '../../package.json'));
   patternlab.config = config || fs.readJSONSync(path.resolve(__dirname, '../../patternlab-config.json'));
   patternlab.events = new PatternLabEventEmitter();
+  // Initialized when building
+  patternlab.graph = null;
 
   checkConfiguration(patternlab);
 
+  //todo: determine if this is the best place to wire up plugins
   initializePlugins(patternlab);
 
   var paths = patternlab.config.paths;
@@ -340,6 +346,7 @@ var patternlab_engine = function (config) {
   function buildPatterns(deletePatternDir) {
 
     patternlab.events.emit('patternlab-build-pattern-start', patternlab);
+    patternlab.graph = PatternGraph.loadFromFile(patternlab);
 
     try {
       patternlab.data = buildPatternData(paths.source.data, fs);
@@ -382,6 +389,7 @@ var patternlab_engine = function (config) {
 
     //diveSync again to recursively include partials, filling out the
     //extendedTemplate property of the patternlab.patterns elements
+    // TODO we can reduce the time needed by only processing changed patterns and their partials
     processAllPatternsRecursive(pattern_assembler, paths.source.patterns, patternlab);
 
     //take the user defined head and foot and process any data and patterns that apply
@@ -394,12 +402,6 @@ var patternlab_engine = function (config) {
 
     //cascade any patternStates
     lineage_hunter.cascade_pattern_states(patternlab);
-
-    //delete the contents of config.patterns.public before writing
-    if (deletePatternDir) {
-      fs.removeSync(paths.public.patterns);
-      fs.emptyDirSync(paths.public.patterns);
-    }
 
     //set pattern-specific header if necessary
     var head;
@@ -414,99 +416,124 @@ var patternlab_engine = function (config) {
       cacheBuster: patternlab.cacheBuster
     });
 
+    let patternsToBuild = patternlab.patterns;
+
+    //delete the contents of config.patterns.public before writing
+    if (deletePatternDir) {
+      fs.removeSync(paths.public.patterns);
+      fs.emptyDirSync(paths.public.patterns);
+    } else {
+      // TODO Find created or deleted files
+      let now = new Date().getTime();
+      var modified = pattern_assembler.find_modified_patterns(now, patternlab);
+      // First mark all modified files
+      for (let p of modified) {
+        p.compileState = CompileState.NEEDS_REBUILD;
+      }
+      patternsToBuild = patternlab.graph.compileOrder();
+    }
+
+
     //render all patterns last, so lineageR works
-    patternlab.patterns.forEach(function (pattern) {
-
-      if (!pattern.isPattern) {
-        return false;
-      }
-
-      //todo move this into lineage_hunter
-      pattern.patternLineages = pattern.lineage;
-      pattern.patternLineageExists = pattern.lineage.length > 0;
-      pattern.patternLineagesR = pattern.lineageR;
-      pattern.patternLineageRExists = pattern.lineageR.length > 0;
-      pattern.patternLineageEExists = pattern.patternLineageExists || pattern.patternLineageRExists;
-
-      patternlab.events.emit('patternlab-pattern-before-data-merge', patternlab, pattern);
-
-      //render the pattern, but first consolidate any data we may have
-      var allData;
-      try {
-        allData = JSON5.parse(JSON5.stringify(patternlab.data));
-      } catch (err) {
-        console.log('There was an error parsing JSON for ' + pattern.relPath);
-        console.log(err);
-      }
-      allData = plutils.mergeData(allData, pattern.jsonFileData);
-      allData.cacheBuster = patternlab.cacheBuster;
-
-      //re-rendering the headHTML each time allows pattern-specific data to influence the head of the pattern
-      pattern.header = head;
-      var headHTML = pattern_assembler.renderPattern(pattern.header, allData);
-
-      //render the extendedTemplate with all data
-      pattern.patternPartialCode = pattern_assembler.renderPattern(pattern, allData);
-
-      // stringify this data for individual pattern rendering and use on the styleguide
-      // see if patternData really needs these other duped values
-      pattern.patternData = JSON.stringify({
-        cssEnabled: false,
-        patternLineageExists: pattern.patternLineageExists,
-        patternLineages: pattern.patternLineages,
-        lineage: pattern.patternLineages,
-        patternLineageRExists: pattern.patternLineageRExists,
-        patternLineagesR: pattern.patternLineagesR,
-        lineageR: pattern.patternLineagesR,
-        patternLineageEExists: pattern.patternLineageExists || pattern.patternLineageRExists,
-        patternDesc: pattern.patternDescExists ? pattern.patternDesc : '',
-        patternBreadcrumb:
-          pattern.patternGroup === pattern.patternSubGroup ?
-          {
-            patternType: pattern.patternGroup
-          } : {
-            patternType: pattern.patternGroup,
-            patternSubtype: pattern.patternSubGroup
-          },
-        patternExtension: pattern.fileExtension.substr(1), //remove the dot because styleguide asset default adds it for us
-        patternName: pattern.patternName,
-        patternPartial: pattern.patternPartial,
-        patternState: pattern.patternState,
-        patternEngineName: pattern.engine.engineName,
-        extraOutput: {}
-      });
-
-      //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
-      var footerPartial = pattern_assembler.renderPattern(patternlab.footer, {
-        isPattern: pattern.isPattern,
-        patternData: pattern.patternData,
-        cacheBuster: patternlab.cacheBuster
-      });
-
-      var allFooterData;
-      try {
-        allFooterData = JSON5.parse(JSON5.stringify(patternlab.data));
-      } catch (err) {
-        console.log('There was an error parsing JSON for ' + pattern.relPath);
-        console.log(err);
-      }
-      allFooterData = plutils.mergeData(allFooterData, pattern.jsonFileData);
-      allFooterData.patternLabFoot = footerPartial;
-
-      var footerHTML = pattern_assembler.renderPattern(patternlab.userFoot, allFooterData);
-
-      patternlab.events.emit('patternlab-pattern-write-begin', patternlab, pattern);
-
-      //write the compiled template to the public patterns directory
-      writePatternFiles(headHTML, pattern, footerHTML);
-
-      patternlab.events.emit('patternlab-pattern-write-end', patternlab, pattern);
-
-      return true;
-    });
-
+    patternsToBuild.forEach( pattern => renderSinglePattern(pattern, head));
+    // Saves the pattern graph when all files have been compiled
+    PatternGraph.storeToFile(patternlab);
+    PatternGraph.exportToDot(patternlab, "dependencyGraph.dot");
     //export patterns if necessary
     pattern_exporter.export_patterns(patternlab);
+  }
+
+  function renderSinglePattern(pattern, head) {
+    // Pattern does not need to be built and recompiled more than once
+    if (!pattern.isPattern || pattern.compileState === CompileState.CLEAN) {
+      return false;
+    }
+    // Allows serializing the compile state
+    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.BUILDING;
+
+    //todo move this into lineage_hunter
+    pattern.patternLineages = pattern.lineage;
+    pattern.patternLineageExists = pattern.lineage.length > 0;
+    pattern.patternLineagesR = pattern.lineageR;
+    pattern.patternLineageRExists = pattern.lineageR.length > 0;
+    pattern.patternLineageEExists = pattern.patternLineageExists || pattern.patternLineageRExists;
+
+    patternlab.events.emit('patternlab-pattern-before-data-merge', patternlab, pattern);
+
+    //render the pattern, but first consolidate any data we may have
+    var allData;
+    try {
+      allData = JSON5.parse(JSON5.stringify(patternlab.data));
+    } catch (err) {
+      console.log('There was an error parsing JSON for ' + pattern.relPath);
+      console.log(err);
+    }
+    allData = plutils.mergeData(allData, pattern.jsonFileData);
+    allData.cacheBuster = patternlab.cacheBuster;
+
+    //re-rendering the headHTML each time allows pattern-specific data to influence the head of the pattern
+    pattern.header = head;
+    var headHTML = pattern_assembler.renderPattern(pattern.header, allData);
+
+    //render the extendedTemplate with all data
+    pattern.patternPartialCode = pattern_assembler.renderPattern(pattern, allData);
+
+    // stringify this data for individual pattern rendering and use on the styleguide
+    // see if patternData really needs these other duped values
+    pattern.patternData = JSON.stringify({
+      cssEnabled: false,
+      patternLineageExists: pattern.patternLineageExists,
+      patternLineages: pattern.patternLineages,
+      lineage: pattern.patternLineages,
+      patternLineageRExists: pattern.patternLineageRExists,
+      patternLineagesR: pattern.patternLineagesR,
+      lineageR: pattern.patternLineagesR,
+      patternLineageEExists: pattern.patternLineageExists || pattern.patternLineageRExists,
+      patternDesc: pattern.patternDescExists ? pattern.patternDesc : '',
+      patternBreadcrumb:
+        pattern.patternGroup === pattern.patternSubGroup ?
+        {
+          patternType: pattern.patternGroup
+        } : {
+          patternType: pattern.patternGroup,
+          patternSubtype: pattern.patternSubGroup
+        },
+      patternExtension: pattern.fileExtension.substr(1), //remove the dot because styleguide asset default adds it for us
+      patternName: pattern.patternName,
+      patternPartial: pattern.patternPartial,
+      patternState: pattern.patternState,
+      patternEngineName: pattern.engine.engineName,
+      extraOutput: {}
+    });
+
+    //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
+    var footerPartial = pattern_assembler.renderPattern(patternlab.footer, {
+      isPattern: pattern.isPattern,
+      patternData: pattern.patternData,
+      cacheBuster: patternlab.cacheBuster
+    });
+
+    var allFooterData;
+    try {
+      allFooterData = JSON5.parse(JSON5.stringify(patternlab.data));
+    } catch (err) {
+      console.log('There was an error parsing JSON for ' + pattern.relPath);
+      console.log(err);
+    }
+    allFooterData = plutils.mergeData(allFooterData, pattern.jsonFileData);
+    allFooterData.patternLabFoot = footerPartial;
+
+    var footerHTML = pattern_assembler.renderPattern(patternlab.userFoot, allFooterData);
+
+    patternlab.events.emit('patternlab-pattern-write-begin', patternlab, pattern);
+
+    //write the compiled template to the public patterns directory
+    writePatternFiles(headHTML, pattern, footerHTML);
+
+    patternlab.events.emit('patternlab-pattern-write-end', patternlab, pattern);
+    // Allows serializing the compile state
+    patternlab.graph.node(pattern).compileState = pattern.compileState = CompileState.CLEAN;
+    return true;
   }
 
   return {

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -514,13 +514,16 @@ var patternlab_engine = function (config) {
     let patternsToBuild = patternlab.patterns;
 
     let graphNeedsUpgrade = !PatternGraph.checkVersion(patternlab.graph);
+
     // Incremental builds are enabled, but we cannot use them
     if (!deletePatternDir && graphNeedsUpgrade) {
       plutils.log.info("Due to an upgrade, a complete rebuild is required. " +
         "Incremental build is available again on the next run.");
+
       // Ensure that the freshly built graph has the latest version again.
       patternlab.graph.upgradeVersion();
     }
+    
     //delete the contents of config.patterns.public before writing
     //Also if the serialized graph must be updated
     if (deletePatternDir || graphNeedsUpgrade) {

--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -58,9 +58,11 @@ var pseudopattern_hunter = function () {
           basePattern: currentPattern,
           stylePartials: currentPattern.stylePartials,
           parameteredPartials: currentPattern.parameteredPartials,
+
           // Only regular patterns are discovered during iterative walks
           // Need to recompile on data change or template change
           lastModified: Math.max(currentPattern.lastModified, lm.mtime),
+
           // use the same template engine as the non-variant
           engine: currentPattern.engine
         }, patternlab);

--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var ch = require('./changes_hunter');
+
 var pseudopattern_hunter = function () {
 
   function findpseudopatterns(currentPattern, patternlab) {
@@ -14,6 +16,7 @@ var pseudopattern_hunter = function () {
 
     var pattern_assembler = new pa();
     var lineage_hunter = new lh();
+    var changes_hunter = new ch();
     var paths = patternlab.config.paths;
 
     //look for a pseudo pattern by checking if there is a file containing same
@@ -62,9 +65,10 @@ var pseudopattern_hunter = function () {
           engine: currentPattern.engine
         }, patternlab);
 
+        changes_hunter.checkBuildState(patternVariant, patternlab);
         patternlab.graph.add(patternVariant);
         patternlab.graph.link(patternVariant, currentPattern);
-        pattern_assembler.check_build_state(currentPattern, patternlab);
+
         //process the companion markdown file if it exists
         pattern_assembler.parse_pattern_markdown(patternVariant, patternlab);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lodash": "~4.13.1",
     "markdown-it": "^6.0.1",
     "node-fetch": "^1.6.0",
-    "patternengine-node-mustache": "^1.0.0"
+    "patternengine-node-mustache": "^1.0.0",
+    "graphlib": "^2.1.1"
   },
   "devDependencies": {
     "chalk": "^1.1.3",

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -61,5 +61,5 @@
     "markupOnly": ".markup-only"
   },
   "cleanOutputHtml": true,
-  "export_graphviz": false
+  "exportToGraphViz": false
 }

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -60,5 +60,6 @@
     "rawTemplate": "",
     "markupOnly": ".markup-only"
   },
-  "cleanOutputHtml": true
+  "cleanOutputHtml": true,
+  "export_graphviz": false
 }

--- a/test/engine_handlebars_tests.js
+++ b/test/engine_handlebars_tests.js
@@ -5,6 +5,7 @@ var tap = require('tap');
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var testPatternsPath = path.resolve(__dirname, 'files', '_handlebars-test-patterns');
 var eol = require('os').EOL;
 
@@ -22,6 +23,7 @@ if (!engineLoader.handlebars) {
 // apparatus.
 function fakePatternLab() {
   var fpl = {
+    graph: PatternGraph.empty(),
     partials: {},
     patterns: [],
     footer: '',

--- a/test/engine_mustache_tests.js
+++ b/test/engine_mustache_tests.js
@@ -3,8 +3,8 @@
 
 var tap  = require('tap');
 var path = require('path');
-var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var testPatternsPath = path.resolve(__dirname, 'files', '_patterns');
 var eol = require('os').EOL;
 
@@ -22,6 +22,7 @@ if (!engineLoader.mustache) {
 // apparatus.
 function fakePatternLab() {
   var fpl = {
+    graph: PatternGraph.empty(),
     partials: {},
     patterns: [],
     footer: '',

--- a/test/engine_twig_tests.js
+++ b/test/engine_twig_tests.js
@@ -6,6 +6,7 @@ var tap = require('tap');
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var eol = require('os').EOL;
 
 // don't run these tests unless twig is installed
@@ -22,6 +23,7 @@ if (!engineLoader.twig) {
 // apparatus.
 function fakePatternLab() {
   var fpl = {
+    graph: PatternGraph.empty(),
     partials: {},
     patterns: [],
     footer: '',

--- a/test/engine_underscore_tests.js
+++ b/test/engine_underscore_tests.js
@@ -3,6 +3,7 @@
 var tap = require('tap');
 var path = require('path');
 var pa = require('../core/lib/pattern_assembler');
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var testPatternsPath = path.resolve(__dirname, 'files', '_underscore-test-patterns');
 var eol = require('os').EOL;
 
@@ -20,6 +21,7 @@ if (!engineLoader.underscore) {
 // apparatus.
 function fakePatternLab() {
   var fpl = {
+    graph: PatternGraph.empty(),
     partials: {},
     patterns: [],
     footer: '',

--- a/test/list_item_hunter_tests.js
+++ b/test/list_item_hunter_tests.js
@@ -4,6 +4,7 @@ var tap = require('tap');
 
 var lih = require('../core/lib/list_item_hunter');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var extend = require('util')._extend;
 var pa = require('../core/lib/pattern_assembler');
 var pattern_assembler = new pa();
@@ -24,6 +25,7 @@ function createFakePatternLab(customProps) {
   //NOTE: These listitems are faked so that pattern_assembler.combine_listitems has already clobbered them.
 
   var pl = {
+    graph: PatternGraph.empty(),
     "listitems": {
       "1": [
         {

--- a/test/pattern_assembler_tests.js
+++ b/test/pattern_assembler_tests.js
@@ -4,9 +4,15 @@ var tap = require('tap');
 
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var CompileState = require('../core/lib/object_factory').CompileState;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 var path = require('path');
 
-
+function emptyPatternLab() {
+  return {
+    graph: PatternGraph.empty()
+  }
+}
 
 tap.test('process_pattern_recursive recursively includes partials', function(test) {
 
@@ -18,9 +24,11 @@ tap.test('process_pattern_recursive recursively includes partials', function(tes
   var plMain = require('../core/lib/patternlab');
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
-  var patternlab = {};
+  var public_dir = './test/public';
+  var patternlab = emptyPatternLab();
   patternlab.config = fs.readJSONSync('./patternlab-config.json');
   patternlab.config.paths.source.patterns = patterns_dir;
+  patternlab.config.paths.public = public_dir;
   patternlab.config.outputFileSuffixes = {rendered: ''};
 
   //patternlab.data = fs.readJSONSync(path.resolve(patternlab.config.paths.source.data, 'data.json'));
@@ -70,7 +78,7 @@ tap.test('processPatternRecursive - correctly replaces all stylemodifiers when m
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -114,7 +122,7 @@ tap.test('processPatternRecursive - correctly replaces multiple stylemodifier cl
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -159,7 +167,7 @@ tap.test('processPatternRecursive - correctly ignores a partial without a style 
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -202,7 +210,7 @@ tap.test('processPatternRecursive - correctly ignores bookended partials without
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -246,7 +254,7 @@ tap.test('processPatternRecursive - correctly ignores a partial without a style 
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -291,7 +299,7 @@ tap.test('processPatternRecursive - correctly ignores bookended partials without
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -336,7 +344,7 @@ tap.test('processPatternRecursive - does not pollute previous patterns when a la
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -390,7 +398,7 @@ tap.test('processPatternRecursive - ensure deep-nesting works', function(test) {
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns';
 
-  var pl = {};
+  var pl = emptyPatternLab();
   pl.config = {
     paths: {
       source: {
@@ -498,7 +506,7 @@ tap.test('parseDataLinks - replaces found link.* data for their expanded links',
   var plMain = require('../core/lib/patternlab');
   var pattern_assembler = new pa();
   var patterns_dir = './test/files/_patterns/';
-  var patternlab = {};
+  var patternlab = emptyPatternLab();
   //THIS IS BAD
   patternlab.config = fs.readJSONSync('./patternlab-config.json');
   patternlab.config.paths.source.patterns = patterns_dir;
@@ -567,7 +575,7 @@ tap.test('parseDataLinks - replaces found link.* data for their expanded links',
 tap.test('get_pattern_by_key - returns the fuzzy result when no others found', function(test) {
   //arrange
   var pattern_assembler = new pa();
-  var patternlab = {};
+  var patternlab = emptyPatternLab();;
   patternlab.patterns = [];
 
   patternlab.patterns.push({
@@ -586,7 +594,7 @@ tap.test('get_pattern_by_key - returns the fuzzy result when no others found', f
 tap.test('get_pattern_by_key - returns the exact key if found', function(test) {
   //arrange
   var pattern_assembler = new pa();
-  var patternlab = {};
+  var patternlab = emptyPatternLab();;
   patternlab.patterns = [];
 
   patternlab.patterns.push({
@@ -609,7 +617,7 @@ tap.test('get_pattern_by_key - returns the exact key if found', function(test) {
 tap.test('addPattern - adds pattern extended template to patternlab partial object', function(test) {
   //arrange
   var pattern_assembler = new pa();
-  var patternlab = {};
+  var patternlab = emptyPatternLab();
   patternlab.patterns = [];
   patternlab.partials = {};
   patternlab.data = {link: {}};
@@ -633,7 +641,7 @@ tap.test('addPattern - adds pattern extended template to patternlab partial obje
 tap.test('addPattern - adds pattern template to patternlab partial object if extendedtemplate does not exist yet', function(test){
   //arrange
   var pattern_assembler = new pa();
-  var patternlab = {};
+  var patternlab = emptyPatternLab();
   patternlab.patterns = [];
   patternlab.partials = {};
   patternlab.data = {link: {}};
@@ -653,6 +661,78 @@ tap.test('addPattern - adds pattern template to patternlab partial object if ext
   test.equals(patternlab.partials['test-bar'], 'bar');
   test.end();
 });
+
+tap.test('findModifiedPatterns - finds patterns modified since a given date', function(test){
+  //arrange
+  var pattern_assembler = new pa();
+  var patternlab = emptyPatternLab();
+  patternlab.partials = {};
+  patternlab.data = {link: {}};
+  patternlab.config = { debug: false };
+  patternlab.config.outputFileSuffixes = {rendered : ''};
+
+  var pattern = new Pattern('00-test/01-bar.mustache');
+  pattern.extendedTemplate = undefined;
+  pattern.template = 'bar';
+  pattern.lastModified = new Date("2016-01-31").getTime();
+  // Initially the compileState is clean,
+  // but we would change this after detecting that the file was modified
+  pattern.compileState = CompileState.CLEAN;
+  patternlab.patterns = [pattern];
+
+  var lastCompilationRun = new Date("2016-01-01").getTime();
+  var p = pattern_assembler.find_modified_patterns(lastCompilationRun, patternlab);
+
+  test.same(p.length, 1, "The pattern was modified after the last compilation");
+
+  lastCompilationRun = new Date("2016-12-31").getTime();
+  p = pattern_assembler.find_modified_patterns(lastCompilationRun, patternlab);
+  test.same(p.length, 0, "Pattern was already compiled and hasn't been modified since last compile");
+  test.end();
+})
+
+tap.test('findModifiedPatterns - finds patterns when modification date is missing', function(test){
+  //arrange
+  var pattern_assembler = new pa();
+  var patternlab = emptyPatternLab();
+  patternlab.partials = {};
+  patternlab.data = {link: {}};
+  patternlab.config = { debug: false };
+  patternlab.config.outputFileSuffixes = {rendered : ''};
+
+  var pattern = new Pattern('00-test/01-bar.mustache');
+  pattern.extendedTemplate = undefined;
+  pattern.template = 'bar';
+  pattern.lastModified = undefined;
+  patternlab.patterns = [pattern];
+
+  let p = pattern_assembler.find_modified_patterns(1000, patternlab);
+  test.same(p.length, 1);
+  test.end();
+});
+
+// This is the case when we want to force recompilation
+tap.test('findModifiedPatterns - finds patterns via compile state', function(test){
+  //arrange
+  var pattern_assembler = new pa();
+  var patternlab = emptyPatternLab();
+  patternlab.partials = {};
+  patternlab.data = {link: {}};
+  patternlab.config = { debug: false };
+  patternlab.config.outputFileSuffixes = {rendered : ''};
+
+  var pattern = new Pattern('00-test/01-bar.mustache');
+  pattern.extendedTemplate = undefined;
+  pattern.template = 'bar';
+  pattern.lastModified = 100000;
+  pattern.compileState = CompileState.NEEDS_REBUILD;
+  patternlab.patterns = [pattern];
+
+  let p = pattern_assembler.find_modified_patterns(1000, patternlab);
+  test.same(p.length, 1);
+  test.end();
+});
+
 
 tap.test('hidden patterns can be called by their nice names', function(test){
   var util = require('./util/test_utils.js');

--- a/test/pattern_graph_tests.js
+++ b/test/pattern_graph_tests.js
@@ -1,0 +1,372 @@
+"use strict";
+
+
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
+var Pattern = require('../core/lib/object_factory').Pattern;
+var CompileState = require('../core/lib/object_factory').CompileState;
+var tap = require('tap');
+
+var patternlab = {
+  config: {
+    paths: {
+      public: {
+        root: "./test/public"
+      }
+    }
+  }
+};
+
+var mockGraph = function () {
+  return PatternGraph.empty();
+};
+
+tap.test("Loading an empty graph works", (test) => {
+  var g = PatternGraph.loadFromFile(patternlab, "does not exist");
+  tap.equal(g.graph.nodes().length, 0,"foo");
+  test.end();
+});
+
+tap.test("PatternGraph.fromJson() - Loading a graph from JSON", (test) => {
+  var graph = PatternGraph.loadFromFile(patternlab, "testDependencyGraph.json");
+  test.same(graph.timestamp, 1337);
+  test.same(graph.graph.nodes(), ["atom-foo", "molecule-foo"]);
+  test.same(graph.graph.edges(), [ {v:"molecule-foo", w: "atom-foo"}]);
+  test.end();
+});
+
+tap.test("toJson() - Storing a graph to JSON correctly", (test) => {
+  var graph = mockGraph();
+  graph.timestamp = 1337;
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  graph.add(atomFoo);
+  graph.add(moleculeFoo);
+  graph.link(moleculeFoo, atomFoo);
+  test.same(graph.toJson(),
+  {"timestamp":1337,"graph":{"options":{"directed":true,"multigraph":false,"compound":false},"nodes":[{"v":"atom-foo","value":{"compileState":"clean"}},{"v":"molecule-foo","value":{"compileState":"clean"}}],"edges":[{"v":"molecule-foo","w":"atom-foo","value":{}}]}});
+  // For generating the above output:console.log(JSON.stringify(graph.toJson()));
+  test.end();
+});
+
+tap.test("Storing and loading a graph from JSON return the identical graph", (test) => {
+  var oldGraph = mockGraph();
+  oldGraph.timestamp = 1337;
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  oldGraph.add(atomFoo);
+  oldGraph.add(moleculeFoo);
+  oldGraph.link(moleculeFoo, atomFoo);
+
+  // act
+  var newGraph = PatternGraph.fromJson(oldGraph.toJson());
+
+  // assert
+  test.same(newGraph.timestamp, 1337);
+  test.same(newGraph.graph.nodes(), ["atom-foo", "molecule-foo"]);
+  test.same(newGraph.graph.edges(), [ {w: "atom-foo", v:"molecule-foo"}]);
+  // The graph is a new object
+  test.notEqual(newGraph, oldGraph);
+  test.end();
+});
+
+
+tap.test("clone()", (test) => {
+  var oldGraph = mockGraph();
+  oldGraph.timestamp = 1337;
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  oldGraph.add(atomFoo);
+  oldGraph.add(moleculeFoo);
+  oldGraph.link(moleculeFoo, atomFoo);
+
+  // act
+  var newGraph = oldGraph.clone();
+
+  // assert
+  test.same(newGraph.timestamp, 1337);
+  test.same(newGraph.graph.nodes(), ["atom-foo", "molecule-foo"]);
+  test.same(newGraph.graph.edges(), [ {w: "atom-foo", v:"molecule-foo"}]);
+  // The graph is a new object
+  test.notEqual(newGraph, oldGraph);
+  test.end();
+});
+
+tap.test("Adding a node", (test) => {
+  var g = mockGraph();
+  var pattern = Pattern.create("atom-foo", null, {compileState:CompileState.CLEAN});
+  g.add(pattern);
+  test.same({compileState:CompileState.CLEAN}, g.node("atom-foo"), "Data were set correctly");
+  var actual = g.nodes();
+  test.same(actual, ["atom-foo"]);
+  test.end();
+});
+
+tap.test("Adding a node twice", (test) => {
+  var g = mockGraph();
+  var pattern = Pattern.create("atom-foo", null, {compileState:CompileState.CLEAN});
+  g.add(pattern);
+  g.add(pattern);
+  var actual = g.nodes();
+  test.same(actual, ["atom-foo"]);
+  test.end();
+});
+
+tap.test("Adding two nodes", (test) => {
+  var g = mockGraph();
+  var atomFoo = Pattern.create("atom-foo", {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", {compileState:CompileState.CLEAN});
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  var actual = g.nodes();
+  test.same(actual, ["atom-foo", "molecule-foo"]);
+  test.end();
+});
+
+tap.test("Adding two nodes with only different subpattern types", (test) => {
+  var g = mockGraph();
+  var atomFoo = Pattern.create("00-atoms/00-foo/baz.html", {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("00-atoms/00-bar/baz.html", {compileState:CompileState.CLEAN});
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  var actual = g.nodes();
+  test.same(actual, ["00-atoms/00-foo/baz.html", "00-atoms/00-bar/baz.html"]);
+  test.end();
+});
+
+tap.test("Linking two nodes", (test) => {
+  var g = mockGraph();
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  g.link(moleculeFoo, atomFoo);
+  test.same(g.graph.edges(), [{v:"molecule-foo",w:"atom-foo"}], "There is an edge from v to w");
+  test.end();
+});
+
+
+tap.test("remove() - Removing a node", (test) => {
+  var g = mockGraph();
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  test.same(g.nodes(), ["atom-foo", "molecule-foo"]);
+  g.remove(moleculeFoo);
+  test.same(g.graph.nodes(), ["atom-foo"], "The molecule was removed from the graph");
+  test.same(g.patterns.allPatterns()[0].relPath, "atom-foo", "The molecule was removed from the known patterns");
+  test.end();
+});
+
+tap.test("filter() - Removing nodes via filter", (test) => {
+  var g = mockGraph();
+  var atomFoo = Pattern.create("atom-foo", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("molecule-foo", null, {compileState:CompileState.CLEAN});
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  test.same(g.nodes(), ["atom-foo", "molecule-foo"]);
+  g.filter(n => n != "molecule-foo");
+  test.same(g.graph.nodes(), ["atom-foo"], "The molecule was removed from the graph");
+  test.same(g.patterns.allPatterns()[0].relPath, "atom-foo", "The molecule was removed from the known patterns");
+  test.end();
+});
+
+// Prevents nodes from escaping the scope, at the same time have some default graph for lineage to
+// test on
+(function () {
+  var atomFoo = Pattern.create("00-atom/xy/foo", null , {compileState:CompileState.CLEAN});
+  var atomIsolated = Pattern.create("00-atom/xy/isolated", null , {compileState:CompileState.CLEAN});
+  var moleculeFoo = Pattern.create("01-molecule/xy/foo", null, {compileState:CompileState.CLEAN});
+  var moleculeBar = Pattern.create("01-molecule/xy/bar", null, {compileState:CompileState.CLEAN});
+  var organismFoo = Pattern.create("02-organism/xy/foo", null, {compileState:CompileState.CLEAN});
+  var organismBar = Pattern.create("02-organism/xy/bar", null, {compileState:CompileState.CLEAN});
+
+  var g = mockGraph();
+
+  // Included nowhere
+  g.add(atomIsolated);
+
+  g.add(atomFoo);
+  g.add(moleculeFoo);
+  g.add(moleculeBar);
+  g.add(organismFoo);
+  g.add(organismBar);
+  // single molecule
+  g.link(organismFoo, moleculeFoo);
+
+  // include two molecules
+  g.link(organismBar, moleculeFoo);
+  g.link(organismBar, moleculeBar);
+
+  // both include atomFoo
+  g.link(moleculeFoo, atomFoo);
+  g.link(moleculeBar, atomFoo);
+
+  tap.test("lineage() - Calculate the lineage of a node", (test) => {
+    test.same(g.lineage(organismFoo).map(p => p.relPath), ["01-molecule/xy/foo"]);
+    test.same(g.lineage(organismBar).map(p => p.relPath), ["01-molecule/xy/foo","01-molecule/xy/bar"]);
+    test.same(g.lineage(moleculeFoo).map(p => p.relPath), ["00-atom/xy/foo"]);
+    test.same(g.lineage(moleculeBar).map(p => p.relPath), ["00-atom/xy/foo"]);
+    test.same(g.lineage(atomFoo).map(p => p.relPath), []);
+    test.same(g.lineage(atomIsolated).map(p => p.relPath), []);
+    test.end();
+  });
+
+  tap.test("lineageIndex() - Calculate the lineage of a node", (test) => {
+    test.same(g.lineageIndex(organismFoo), ["molecule-foo"]);
+    test.same(g.lineageIndex(organismBar), ["molecule-foo", "molecule-bar"]);
+    test.same(g.lineageIndex(moleculeFoo), ["atom-foo"]);
+    test.same(g.lineageIndex(moleculeBar), ["atom-foo"]);
+    test.same(g.lineageIndex(atomFoo), []);
+    test.same(g.lineageIndex(atomIsolated), []);
+    test.end();
+  });
+
+  tap.test("lineageR() - Calculate the reverse lineage of a node", (test) => {
+    test.same(g.lineageR(organismFoo).map(p => p.relPath), []);
+    test.same(g.lineageR(organismBar).map(p => p.relPath), []);
+    test.same(g.lineageR(moleculeFoo).map(p => p.relPath), ["02-organism/xy/foo", "02-organism/xy/bar"]);
+    test.same(g.lineageR(moleculeBar).map(p => p.relPath), ["02-organism/xy/bar"]);
+    test.same(g.lineageR(atomFoo).map(p => p.relPath), ["01-molecule/xy/foo", "01-molecule/xy/bar"]);
+    test.same(g.lineageR(atomIsolated).map(p => p.relPath), []);
+    test.end();
+  });
+
+  tap.test("lineageRIndex() - Calculate the lineage index of a node", (test) => {
+    test.same(g.lineageRIndex(organismFoo), []);
+    test.same(g.lineageRIndex(organismBar), []);
+    test.same(g.lineageRIndex(moleculeFoo), ["organism-foo", "organism-bar"]);
+    test.same(g.lineageRIndex(moleculeBar), ["organism-bar"]);
+    test.same(g.lineageRIndex(atomFoo), ["molecule-foo", "molecule-bar"]);
+    test.same(g.lineageRIndex(atomIsolated), []);
+    test.end();
+  });
+})();
+
+(function () {
+
+  function TestGraph() {
+
+    function csAt(args, idx) {
+      return {compileState: args[idx] || CompileState.CLEAN}
+    }
+    var i = 0;
+    var atomFoo = this.atomFoo = Pattern.create("00-atom/xy/foo", null, csAt(arguments,i++));
+    var atomIsolated = this.atomIsolated = Pattern.create("00-atom/xy/isolated", null, csAt(arguments,i++));
+    var moleculeFoo = this.moleculeFoo = Pattern.create("01-molecule/xy/foo", null, csAt(arguments,i++));
+    var moleculeBar = this.moleculeBar = Pattern.create("01-molecule/xy/bar", null, csAt(arguments,i++));
+    var organismFoo = this.organismFoo = Pattern.create("02-organism/xy/foo", null, csAt(arguments,i++));
+    var organismBar = this.organismBar = Pattern.create("02-organism/xy/bar", null, csAt(arguments,i++));
+
+    var graph = this.graph = mockGraph();
+
+    // Included nowhere
+    graph.add(atomIsolated);
+
+    graph.add(atomFoo);
+    graph.add(moleculeFoo);
+    graph.add(moleculeBar);
+    graph.add(organismFoo);
+    graph.add(organismBar);
+    // single molecule
+    graph.link(organismFoo, moleculeFoo);
+
+    // include two molecules
+    graph.link(organismBar, moleculeFoo);
+    graph.link(organismBar, moleculeBar);
+
+    // both include atomFoo
+    graph.link(moleculeFoo, atomFoo);
+    graph.link(moleculeBar, atomFoo);
+
+
+  }
+
+  tap.test("compileOrder() - A clean graph results in no nodes to recompile", (test) => {
+    var g = new TestGraph();
+    var co = g.graph.compileOrder();
+    test.equals(0, co.length);
+    test.end();
+  });
+
+  tap.test("compileOrder() - Recompile isolated atoms does not do anything else", (test) => {
+    var g = new TestGraph(
+      // atomFoo
+      CompileState.CLEAN,
+      // atomIsolated
+      CompileState.NEEDS_REBUILD);
+
+    var co = g.graph.compileOrder();
+    test.same([g.atomIsolated], co, "Only recompile atomIsolated");
+    co.forEach( p=> test.same(p.compileState, CompileState.NEEDS_REBUILD,
+      "All patterns are marked for rebuilding"));
+
+    test.end();
+  });
+
+  tap.test("compileOrder() - Changing a linked atom bubbles back to the organisms", (test) => {
+    // Almost every pattern - except atomIsolated - has a transitive dependency on atomFoo
+    var g = new TestGraph(CompileState.NEEDS_REBUILD);
+    var co = g.graph.compileOrder();
+
+    test.equals(5, co.length);
+    test.same([g.atomFoo, g.moleculeFoo, g.organismFoo, g.moleculeBar, g.organismBar], co,
+    "Recompile everything except atomIsolated");
+    co.forEach( p=> test.same(p.compileState, CompileState.NEEDS_REBUILD,
+      "All patterns are marked for rebuilding"));
+
+    test.end();
+  });
+
+
+  tap.test("compileOrder() - Changing a molecule leaves atoms untouched", (test) => {
+    // Bubble up from molecules to organisms, leaving atoms unchanged as they were not modified
+    var g = new TestGraph(null, null, CompileState.NEEDS_REBUILD);
+    var co = g.graph.compileOrder();
+
+    test.same([g.moleculeFoo, g.organismFoo, g.organismBar], co,
+      "Recompile moleculeFoo and transitive dependencies");
+    co.forEach( p=> test.same(p.compileState, CompileState.NEEDS_REBUILD,
+      "All patterns are marked for rebuilding"));
+    test.end();
+  });
+
+  tap.test("compileOrder() - Changing an organism leaves atoms and molecules untouched", (test) => {
+    // Almost every pattern - except atomIsolated - has a transitive dependency on atomFoo
+    var g = new TestGraph(
+      // atoms
+      null, null,
+      // molecules
+      null, null,
+      // organismFoo
+      CompileState.NEEDS_REBUILD);
+    var co = g.graph.compileOrder();
+
+    test.same([g.organismFoo], co);
+    test.same(co[0].compileState, CompileState.NEEDS_REBUILD,
+      "All patterns are marked for rebuilding");
+    test.end();
+  });
+
+
+  tap.test("compileOrder() - Recompile everything", (test) => {
+    // Almost every pattern - except atomIsolated - has a transitive dependency on atomFoo
+    // Also recompile atomIsolated
+    var g = new TestGraph( CompileState.NEEDS_REBUILD, CompileState.NEEDS_REBUILD);
+    var compileOrder = g.graph.compileOrder();
+
+    test.same([
+        g.atomIsolated,
+        g.atomFoo,
+        g.moleculeFoo,
+        g.organismFoo,
+        g.moleculeBar,
+        g.organismBar
+      ],
+      compileOrder,
+      "Recompile everything except atomIsolated");
+    compileOrder.forEach( p=> test.same(p.compileState, CompileState.NEEDS_REBUILD,
+      "All patterns are marked for rebuilding"));
+    test.end();
+  });
+})();

--- a/test/pattern_registry_tests.js
+++ b/test/pattern_registry_tests.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var PatternRegistry = require('./../core/lib/pattern_registry');
+
+var tap = require('tap');
+
+// #540 Copied from pattern_assembler_tests
+tap.test('get_pattern_by_key - returns the fuzzy result when no others found', function(test) {
+  var pattern_registry = new PatternRegistry();
+
+  var pattern = {
+    key: 'character-han-solo',
+    patternPartial: 'character-han-solo',
+    subdir: 'character',
+    fileName: 'han-solo'
+  };
+  pattern_registry.put(pattern);
+
+  //act
+  var result = pattern_registry.getPartial('character-han');
+  //assert
+  test.equals(result, pattern);
+  test.end();
+});
+
+// #540 Copied from pattern_assembler_tests
+tap.test('remove - remove an existing pattern', function(test) {
+  var pattern_registry = new PatternRegistry();
+
+  var pattern = {
+    key: 'character-han-solo',
+    patternPartial: 'character-han-solo',
+    subdir: 'character',
+    fileName: 'han-solo'
+  };
+  pattern_registry.put(pattern);
+
+  //act
+  pattern_registry.remove('character-han-solo');
+  test.same(null, pattern_registry.get('character-han-solo'));
+  test.end();
+});
+
+// #540 Copied from pattern_assembler_tests
+tap.test('getPartial - returns the exact key if found', function(test) {
+  //arrange
+  var pattern_registry = new PatternRegistry();
+  let patterns = [{
+    key: 'molecules-primary-nav-jagged',
+    patternPartial: 'molecules-primary-nav-jagged',
+      subdir: 'molecules',
+    fileName: 'primary-nav-jagged'
+  }, {
+    key: 'molecules-primary-nav',
+    patternPartial: 'molecules-primary-nav',
+      subdir: 'molecules',
+      fileName: 'molecules-primary-nav'
+  }];
+  patterns.forEach((p) => pattern_registry.put(p));
+
+  //act
+  var result = pattern_registry.getPartial('molecules-primary-nav');
+  //assert
+  test.equals(result, patterns[1]);
+  test.end();
+});

--- a/test/pseudopattern_hunter_tests.js
+++ b/test/pseudopattern_hunter_tests.js
@@ -6,18 +6,24 @@ var path = require('path');
 var pha = require('../core/lib/pseudopattern_hunter');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
+var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 
 var fs = require('fs-extra');
 var pattern_assembler = new pa();
 var pseudopattern_hunter = new pha();
 var patterns_dir = './test/files/_patterns/';
+var public_patterns_dir = './test/public/patterns';
 
 function stubPatternlab() {
   var pl = {};
+  pl.graph = PatternGraph.empty();
   pl.config = {
     paths: {
       source: {
         patterns: patterns_dir
+      },
+      public: {
+        patterns: public_patterns_dir
       }
     }
   };
@@ -27,7 +33,7 @@ function stubPatternlab() {
   pl.patterns = [];
   pl.partials = {};
   pl.config.patternStates = {};
-  pl.config.outputFileSuffixes = { rendered: ''}
+  pl.config.outputFileSuffixes = { rendered: ''};
 
   return pl;
 }

--- a/test/public/testDependencyGraph.json
+++ b/test/public/testDependencyGraph.json
@@ -1,1 +1,1 @@
-{"timestamp":1337,"graph":{"options":{"directed":true,"multigraph":false,"compound":false},"nodes":[{"v":"atom-foo","value":{"compileState":"clean"}},{"v":"molecule-foo","value":{"compileState":"clean"}}],"edges":[{"v":"molecule-foo","w":"atom-foo","value":{}}]}}
+{"version":1,"timestamp":1337,"graph":{"options":{"directed":true,"multigraph":false,"compound":false},"nodes":[{"v":"atom-foo","value":{"compileState":"clean"}},{"v":"molecule-foo","value":{"compileState":"clean"}}],"edges":[{"v":"molecule-foo","w":"atom-foo","value":{}}]}}

--- a/test/public/testDependencyGraph.json
+++ b/test/public/testDependencyGraph.json
@@ -1,0 +1,1 @@
+{"timestamp":1337,"graph":{"options":{"directed":true,"multigraph":false,"compound":false},"nodes":[{"v":"atom-foo","value":{"compileState":"clean"}},{"v":"molecule-foo","value":{"compileState":"clean"}}],"edges":[{"v":"molecule-foo","w":"atom-foo","value":{}}]}}

--- a/test/util/test_utils.js
+++ b/test/util/test_utils.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var PatternGraph = require('./../../core/lib/pattern_graph').PatternGraph;
+
 module.exports = {
 
   // fake pattern lab constructor:
@@ -7,6 +9,7 @@ module.exports = {
   // apparatus.
   fakePatternLab: (testPatternsPath) => {
     var fpl = {
+      graph: PatternGraph.empty(),
       partials: {},
       patterns: [],
       footer: '',


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

_Addresses #540 _

### Summary of changes:
This is a prototype for recompiling any templates that have been modified since they have been previously built. This works by inspecting the source and output files' modification timestamps.
A pattern is marked as `needs rebuild` if any of its source files was modified after the modification timestamp of the output file. When the template was built and the output was written to disk, it is marked as `clean` to prevent building templates more than once.
### Working

A pattern is recompiled iif
- the template itself was modified
- its data (companion json) was modified
- it is a pseudo-pattern and the according json file was modified
- existing unit tests are running
### Not working yet
- [ ] When using grunt, `patternlab:serve` will wipe the output folder. We can provide a seperate goal.