### PR TITLE
Bugfix/586 incremental viewall

### DIFF
--- a/core/lib/changes_hunter.js
+++ b/core/lib/changes_hunter.js
@@ -27,13 +27,23 @@ ChangesHunter.prototype = {
     let renderedTemplatePath =
       patternlab.config.paths.public.patterns + pattern.getPatternLink(patternlab, 'rendered');
 
+    //write the compiled template to the public patterns directory
+    let markupOnlyPath =
+      patternlab.config.paths.public.patterns + pattern.getPatternLink(patternlab, 'markupOnly');
+
     if (!pattern.compileState) {
       pattern.compileState = CompileState.NEEDS_REBUILD;
     }
 
     try {
-      // Prevent error message if file does not exist
-      fs.accessSync(renderedTemplatePath, fs.F_OK);
+
+      // renderedTemplatePath required to display a single element
+      // Markup only is required for "View All" pages. It will get loaded later on.
+      // If any of these is missing, mark pattern for recompile
+      [renderedTemplatePath, markupOnlyPath].forEach(renderedFile =>
+        // Prevent error message if file does not exist
+        fs.accessSync(renderedFile, fs.F_OK)
+      );
       let outputLastModified = fs.statSync(renderedTemplatePath).mtime.getTime();
 
       if (pattern.lastModified && outputLastModified > pattern.lastModified) {
@@ -76,6 +86,13 @@ ChangesHunter.prototype = {
         // Ignore, not a regular file
       }
     }
+  },
+
+  needsRebuild: function(lastModified, p) {
+    if (p.compileState !== CompileState.CLEAN || ! p.lastModified) {
+      return true;
+    }
+    return p.lastModified >= lastModified;
   }
 };
 

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var path = require('path'),
+  _ = require('lodash'),
   fs = require('fs-extra'),
   Pattern = require('./object_factory').Pattern,
   CompileState = require('./object_factory').CompileState,
@@ -406,13 +407,40 @@ var pattern_assembler = function () {
     decomposePattern(currentPattern, patternlab);
   }
 
-  function findModifiedPatterns(lastModified, patternlab) {
-    return patternlab.patterns.filter(p => {
-      if (p.compileState !== CompileState.CLEAN || ! p.lastModified) {
-        return true;
+
+  /**
+   * Finds patterns that were modified and need to be rebuilt. For clean patterns load the already
+   * rendered markup.
+   *
+   * @param lastModified
+   * @param patternlab
+   */
+  function markModifiedPatterns(lastModified, patternlab) {
+    /**
+     * If the given array exists, apply a function to each of its elements
+     * @param {Array} array
+     * @param {Function} func
+     */
+    const forEachExisting = (array, func) => {
+      if (array) {
+        array.forEach(func);
       }
-      return p.lastModified >= lastModified;
+    };
+    const modifiedOrNot = _.groupBy(
+      patternlab.patterns,
+      p => changes_hunter.needsRebuild(lastModified, p) ? 'modified' : 'notModified');
+
+    // For all unmodified patterns load their rendered template output
+    forEachExisting(modifiedOrNot.notModified, cleanPattern => {
+      const xp = path.join(patternlab.config.paths.public.patterns, cleanPattern.getPatternLink(patternlab, 'markupOnly'));
+
+      // Pattern with non-existing markupOnly files were already marked for rebuild and thus are not "CLEAN"
+      cleanPattern.patternPartialCode = fs.readFileSync(xp, 'utf8');
     });
+
+    // For all patterns that were modified, schedule them for rebuild
+    forEachExisting(modifiedOrNot.modified, p => p.compileState = CompileState.NEEDS_REBUILD);
+    return modifiedOrNot;
   }
 
   function expandPartials(foundPatternPartials, list_item_hunter, patternlab, currentPattern) {
@@ -528,8 +556,8 @@ var pattern_assembler = function () {
   }
 
   return {
-    find_modified_patterns: function (lastModified, patternlab) {
-      return findModifiedPatterns(lastModified, patternlab);
+    mark_modified_patterns: function (lastModified, patternlab) {
+      return markModifiedPatterns(lastModified, patternlab);
     },
     find_pattern_partials: function (pattern) {
       return pattern.findPartials();

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -564,12 +564,7 @@ var patternlab_engine = function (config) {
 
       // TODO Find created or deleted files
       let now = new Date().getTime();
-      let modified = pattern_assembler.find_modified_patterns(now, patternlab);
-
-      // First mark all modified files
-      for (let p of modified) {
-        p.compileState = CompileState.NEEDS_REBUILD;
-      }
+      pattern_assembler.mark_modified_patterns(now, patternlab);
       patternsToBuild = patternlab.graph.compileOrder();
     } else {
       // build all patterns, mark all to be rebuilt


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #586 

Summary of changes:
If a pattern does not need to be recompiled, load the previously built template output (markup only)