### PR TITLE
use path.sep to match omitted directories

### DIFF
--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -82,7 +82,7 @@ var ui_builder = function () {
     }
 
     //this pattern is contained with a directory prefixed with an underscore (a handy way to hide whole directories from the nav
-    isOmitted = pattern.relPath.charAt(0) === '_' || pattern.relPath.indexOf('/_') > -1;
+    isOmitted = pattern.relPath.charAt(0) === '_' || pattern.relPath.indexOf(path.sep + '_') > -1;
     if (isOmitted) {
       if (patternlab.config.debug) {
         console.log('Omitting ' + pattern.patternPartial + ' from styleguide patterns because its contained within an underscored directory.');


### PR DESCRIPTION
replace '/' with path.sep to work in both Windows and POSIX env

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #596

Summary of changes:
Replacing forward slash with `path.sep` to match `pattern.relPath`