### PR TITLE
Add pattern export all

### DIFF
--- a/core/lib/pattern_exporter.js
+++ b/core/lib/pattern_exporter.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var fs = require('fs-extra');
+var path = require('path');
 
 var pattern_exporter = function () {
 
@@ -19,7 +20,7 @@ var pattern_exporter = function () {
     if (exportAll) {
       for (var i = 0; i < patternlab.patterns.length; i++) {
         if (!patternlab.patterns[i].patternPartial.startsWith('-')) {
-          fs.outputFileSync(patternlab.config.patternExportDirectory + patternlab.patterns[i].patternPartial + '.html', patternlab.patterns[i].patternPartialCode);
+          exportSinglePattern(patternlab, patternlab.patterns[i]);
         }
       }
 
@@ -31,10 +32,24 @@ var pattern_exporter = function () {
       for (var j = 0; j < patternlab.patterns.length; j++) {
         if (exportPartials[i] === patternlab.patterns[j].patternPartial) {
           //write matches to the desired location
-          fs.outputFileSync(patternlab.config.patternExportDirectory + patternlab.patterns[j].patternPartial + '.html', patternlab.patterns[j].patternPartialCode);
+          exportSinglePattern(patternlab, patternlab.patterns[j]);
         }
       }
     }
+  }
+
+  function exportSinglePattern(patternlab, pattern) {
+    var preserveDirStructure = patternlab.config.patternExportPreserveDirectoryStructure;
+    var patternName = pattern.patternPartial;
+    var patternDir = patternlab.config.patternExportDirectory;
+    if (preserveDirStructure) {
+      // Extract the first part of the pattern partial as the directory in which
+      // it should go.
+      patternDir = path.join(patternDir, pattern.patternPartial.split('-')[0]);
+      patternName = pattern.patternPartial.split('-').slice(1).join('-');
+    }
+
+    fs.outputFileSync(path.join(patternDir, patternName) + '.html', pattern.patternPartialCode);
   }
 
   return {

--- a/core/lib/pattern_exporter.js
+++ b/core/lib/pattern_exporter.js
@@ -14,6 +14,17 @@ var pattern_exporter = function () {
   function exportPatterns(patternlab) {
     //read the config export options
     var exportPartials = patternlab.config.patternExportPatternPartials;
+    var exportAll = patternlab.config.patternExportAll;
+
+    if (exportAll) {
+      for (var i = 0; i < patternlab.patterns.length; i++) {
+        if (!patternlab.patterns[i].patternPartial.startsWith('-')) {
+          fs.outputFileSync(patternlab.config.patternExportDirectory + patternlab.patterns[i].patternPartial + '.html', patternlab.patterns[i].patternPartialCode);
+        }
+      }
+
+      return;
+    }
 
     //find the chosen patterns to export
     for (var i = 0; i < exportPartials.length; i++) {

--- a/core/lib/pattern_exporter.js
+++ b/core/lib/pattern_exporter.js
@@ -42,6 +42,8 @@ var pattern_exporter = function () {
     var preserveDirStructure = patternlab.config.patternExportPreserveDirectoryStructure;
     var patternName = pattern.patternPartial;
     var patternDir = patternlab.config.patternExportDirectory;
+    var patternCode = pattern.patternPartialCode;
+    var patternFileExtension = ".html";
     if (preserveDirStructure) {
       // Extract the first part of the pattern partial as the directory in which
       // it should go.
@@ -49,7 +51,12 @@ var pattern_exporter = function () {
       patternName = pattern.patternPartial.split('-').slice(1).join('-');
     }
 
-    fs.outputFileSync(path.join(patternDir, patternName) + '.html', pattern.patternPartialCode);
+    if (patternlab.config.patternExportRaw) {
+      patternCode = pattern.extendedTemplate;
+      patternFileExtension = "." + JSON.parse(pattern.patternData).patternExtension;
+    }
+
+    fs.outputFileSync(path.join(patternDir, patternName) + patternFileExtension, patternCode);
   }
 
   return {

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -53,6 +53,7 @@
   "patternStates": {
   },
   "patternExportAll": false,
+  "patternExportPreserveDirectoryStructure": false,
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -52,6 +52,7 @@
   "patternStateCascade": ["inprogress", "inreview", "complete"],
   "patternStates": {
   },
+  "patternExportAll": false,
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -54,6 +54,7 @@
   },
   "patternExportAll": false,
   "patternExportPreserveDirectoryStructure": false,
+  "patternExportRaw": false,
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,


### PR DESCRIPTION
**Use Case**: We use pattern-lab to create a rough design, then export all of our styles and patterns to a rails web application. This PR seeks to make the export more user-friendly by: 
  1. Allowing us to export raw patterns (.mustache files) which can be interpreted by the ruby mustache template engine.
  2. Preserving directory structure of our atoms/molecules/etc... such that we don't have _too_ much directory hierarchy, but one level deeper than just a flat directory structure.
  3. Allowing us to easily specify that we want _all_ patterns to be exported, rather than having to manually specify each one (as our designs are in flux constantly right now, and there are many changes).

Summary of changes:
  - Add capability to export all patterns via a flag in `patternlab-config.json`.
  - Add capability to preserve rough directory structure via a flag in `patternlab-config.json`.
  - Add capability to export raw patterns via flag in `patternlab-config.json`.

_Note_: This is a sort of rough start to a PR. I don't expect that it's going to be approved initially, but rather it's more of a starting point. It doesn't conform to the pattern-lab spec, although, I _do_ know PHP, and would be willing to change the pattern-lab PHP code as well as the node code (node just happens to be what we use right now), but I'm not 100% sure how to go about adding this to the spec. Typically, a proof-of-concept/starting-point implementation tends to be required before modifying a specification, anyway, so this should serve as that. (This is the reason the documentation for the new flags added in `patternlab-config.json` wasn't added).