### PR TITLE
adding test coverage with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ source/css/style.css.map
 public
 !test/patterns/public/.gitkeep
 !test/patterns/testDependencyGraph.json
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "eslint": "^3.5.0",
+    "nyc": "10.1.2",
     "rewire": "^2.5.2",
     "tap": "^7.1.2"
   },
@@ -51,7 +52,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "eslint core/**/*.js && tap test/*_tests.js --reporter spec",
+    "test": "eslint core/**/*.js && nyc tap test/*_tests.js --reporter spec",
     "lint": "eslint core/**/*.js"
   },
   "engines": {


### PR DESCRIPTION
I tested this on both the dev and dev-3.0 branch. I can make the pull request to either branch.
@bmuenzenmeyer @raphaelokon 
Summary of changes:
- Adds test coverage using the nyc package
- updated .gitignore to exclude ..nyc_output/
- updated npm test command to include nyc command