### PR TITLE
Option of excluding sub pattern types from the styleguide

### DIFF
--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -515,7 +515,7 @@ var ui_builder = function () {
           });
         if (omitPatternType) {
           if (patternlab.config.debug) {
-            console.log('Omitting ' + patternType + '/' + patternSubtype + ' from  building a viewall page because its patternGroup is specified in styleguideExcludes.');
+            console.log('Omitting ' + patternType + '/' + patternSubtype + ' from  building a viewall page because its patternSubGroup is specified in styleguideExcludes.');
           }
         } else {
           styleguideTypePatterns = styleguideTypePatterns.concat(subtypePatterns);

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -484,7 +484,7 @@ var ui_builder = function () {
     _.forEach(styleguidePatterns.patternGroups, function (patternTypeObj, patternType) {
 
       var p;
-      var typePatterns = [];
+      var typePatterns = [], styleGuidePatterns = [];
       var styleGuideExcludes = patternlab.config.styleGuideExcludes;
 
       _.forOwn(patternTypeObj, function (patternSubtypes, patternSubtype) {
@@ -507,6 +507,19 @@ var ui_builder = function () {
         p = _.find(subtypePatterns, function (pat) {
           return pat.isDocPattern;
         });
+
+        //determine if we should omit this subpatterntype completely from the viewall page
+        var omitPatternType = styleGuideExcludes && styleGuideExcludes.length
+          && _.some(styleGuideExcludes, function (exclude) {
+            return exclude === patternType + '/' + patternSubtype;
+          });
+        if (omitPatternType) {
+          if (patternlab.config.debug) {
+            console.log('Omitting ' + patternType + '/' + patternSubtype + ' from  building a viewall page because its patternGroup is specified in styleguideExcludes.');
+          }
+        } else {
+          styleguidePatterns = styleguidePatterns.concat(subtypePatterns);
+        }
 
         typePatterns = typePatterns.concat(subtypePatterns);
 
@@ -544,7 +557,7 @@ var ui_builder = function () {
           console.log('Omitting ' + patternType + ' from  building a viewall page because its patternGroup is specified in styleguideExcludes.');
         }
       } else {
-        patterns = patterns.concat(typePatterns);
+        patterns = patterns.concat(styleguidePatterns);
       }
     });
     return patterns;

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -484,7 +484,7 @@ var ui_builder = function () {
     _.forEach(styleguidePatterns.patternGroups, function (patternTypeObj, patternType) {
 
       var p;
-      var typePatterns = [], styleGuidePatterns = [];
+      var typePatterns = [], styleguideTypePatterns = [];
       var styleGuideExcludes = patternlab.config.styleGuideExcludes;
 
       _.forOwn(patternTypeObj, function (patternSubtypes, patternSubtype) {
@@ -518,7 +518,7 @@ var ui_builder = function () {
             console.log('Omitting ' + patternType + '/' + patternSubtype + ' from  building a viewall page because its patternGroup is specified in styleguideExcludes.');
           }
         } else {
-          styleguidePatterns = styleguidePatterns.concat(subtypePatterns);
+          styleguideTypePatterns = styleguideTypePatterns.concat(subtypePatterns);
         }
 
         typePatterns = typePatterns.concat(subtypePatterns);
@@ -557,7 +557,7 @@ var ui_builder = function () {
           console.log('Omitting ' + patternType + ' from  building a viewall page because its patternGroup is specified in styleguideExcludes.');
         }
       } else {
-        patterns = patterns.concat(styleguidePatterns);
+        patterns = patterns.concat(styleguideTypePatterns);
       }
     });
     return patterns;


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses: Option of excluding sub pattern types from the styleguide

Summary of changes:
* Replicated omitPatternType for 'patternType/patternSubtype'
* Duplicated typePatterns as styleguideTypePatterns to seperate stylguide and nav menu creation.