### PR TITLE
Bugfix/629 starterkit race

### DIFF
--- a/core/lib/starterkit_manager.js
+++ b/core/lib/starterkit_manager.js
@@ -36,12 +36,13 @@ var starterkit_manager = function (config) {
           console.log('Overwriting contents of', paths.source.root, 'during starterkit load.');
         }
 
-        fs.copy(kitPath, paths.source.root, function (ex) {
-          if (ex) {
-            console.error(ex);
-          }
-          util.debug('starterkit ' + starterkitName + ' loaded successfully.');
-        });
+        try {
+          fs.copySync(kitPath, paths.source.root);
+        } catch (ex) {
+          util.error(ex);
+          return;
+        }
+        util.debug('starterkit ' + starterkitName + ' loaded successfully.');
       }
     } catch (ex) {
       console.log(ex);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #629 Race condition when loading starter kits

Summary of changes: Make fs.copy synchronous
