### PR TITLE
Feature/628 starterkit config

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -270,7 +270,8 @@ var patternlab_engine = function (config) {
   }
 
   function loadStarterKit(starterkitName, clean) {
-    var starterkit_manager = new sm(patternlab.config);
+    const configPath = path.resolve(process.cwd(), 'patternlab-config.json');
+    const starterkit_manager = new sm(patternlab.config, configPath);
     starterkit_manager.load_starterkit(starterkitName, clean);
   }
 

--- a/core/scripts/postinstall.js
+++ b/core/scripts/postinstall.js
@@ -16,12 +16,12 @@ try {
   var config = fs.readJSONSync(path.resolve(configPath), 'utf8');
 
   //determine if any starterkits are already installed
-  var starterkit_manager = new sm(config);
+  var starterkit_manager = new sm(config, configPath);
   var foundStarterkits = starterkit_manager.detect_starterkits();
 
   //todo - enhance to support multiple kits with prompt for each or all
   if (foundStarterkits && foundStarterkits.length > 0) {
-    starterkit_manager.load_starterkit(foundStarterkits[0], true);
+    starterkit_manager.load_starterkit(foundStarterkits[0], configPath, true);
   } else {
     console.log('No starterkits found to automatically load.');
   }

--- a/core/scripts/postinstall.js
+++ b/core/scripts/postinstall.js
@@ -21,7 +21,7 @@ try {
 
   //todo - enhance to support multiple kits with prompt for each or all
   if (foundStarterkits && foundStarterkits.length > 0) {
-    starterkit_manager.load_starterkit(foundStarterkits[0], configPath, true);
+    starterkit_manager.load_starterkit(foundStarterkits[0], true);
   } else {
     console.log('No starterkits found to automatically load.');
   }

--- a/test/starterkit_manager_tests.js
+++ b/test/starterkit_manager_tests.js
@@ -1,0 +1,139 @@
+"use strict";
+const tap = require('tap');
+const path = require('path');
+const rewire = require('rewire');
+
+// eslint-disable-next-line no-unused-vars
+const fs = require('fs-extra');
+
+
+let config = {
+  "not": "overwritten",
+  "patternExtension": "mustache",
+  "anArray": ["foo", "bar"],
+  "nestedObject": {
+    "foo": 1,
+    "bar": "original"
+  },
+  "paths": {"source": {"root": "./source/"} }
+};
+
+tap.test("StarterKit configuration works as excepted", function (test) {
+  const starterkit_manager = rewire('../core/lib/starterkit_manager');
+
+  //set up a global mocks - we don't want to be writing/rendering any files right now
+  const fsMock = {
+    readJSONSync: function (thePath) {
+      if (thePath.endsWith("patternlab-config.json")) {
+
+        return config;
+      }
+
+      if (thePath.endsWith("starterkit-config.json")) {
+        return {
+          "patternExtension": "html",
+          "anArray": ["baz"],
+          "nestedObject": {
+            "bar": "overwritten"
+          },
+          "newField": "value"
+        };
+      }
+      throw "Never happens";
+    },
+    copySync: function () {
+
+    },
+    statSync: function () {
+      return {
+        isDirectory: function () {
+          return true;
+        }
+      };
+    },
+    outputFileSync: function (file, data) {
+      test.same(
+        JSON.parse(data), {
+          "not": "overwritten",
+          "patternExtension": "html",
+          "anArray": ["baz"],
+          "nestedObject": {
+            "foo": 1,
+            "bar": "overwritten"
+          },
+          "paths": {"source": {"root": "./source/"}},
+          "newField": "value"
+        }, "The configuration is overwritten correctly"
+      );
+    }
+  };
+
+  //set our mocks in place of usual require()
+  starterkit_manager.__set__({
+    'fs': fsMock,
+    'path': {
+      resolve: function () {
+        return Array.prototype.slice.call(arguments).join(path.sep);
+      },
+      join: function () {
+        return Array.prototype.slice.call(arguments).join(path.sep);
+      }
+    }
+  });
+
+  const sm = new starterkit_manager(config, "patternlab-config.json");
+  sm.load_starterkit("starterkit-foo", false);
+  test.end();
+});
+
+
+
+tap.test("StarterKit configuration is not mandatory", function (test) {
+  const starterkit_manager = rewire('../core/lib/starterkit_manager');
+  const starterkitConfig = "starterkit-config.json";
+
+//set up a global mocks - we don't want to be writing/rendering any files right now
+  const fsMock = {
+    readJSONSync: function (thePath) {
+      if (thePath.endsWith("patternlab-config.json")) {
+        return config;
+      }
+      if (thePath.endsWith(starterkitConfig)) {
+        throw new Error("File does not exist");
+      }
+      throw "Never happens";
+    },
+    copySync: function () { },
+    statSync: function (file) {
+      if (file === starterkitConfig) {
+        throw new Error("File does not exist");
+      }
+      return {
+        isDirectory: function () {
+          return true;
+        }
+      };
+    },
+    outputFileSync: function (file, data) {
+      // config is not modified when file does not exist
+      test.same(JSON.parse(data), config, "The configuration is overwritten correctly");
+    }
+  };
+
+//set our mocks in place of usual require()
+  starterkit_manager.__set__({
+    'fs': fsMock,
+    'path': {
+      resolve: function () {
+        return Array.prototype.slice.call(arguments).join(path.sep);
+      },
+      join: function () {
+        return "";
+      }
+    }
+  });
+
+  const sm = new starterkit_manager(config, "patternlab-config.json");
+  sm.load_starterkit("starterkit-foo", false);
+  test.end();
+});


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

**Addresses #628  StarterKits should be able to override settings in `patternlab-config.json`**

Summary of changes:
1. read `starterkit-config.json`
2. Deep merge into `patternlab-config.json`. Existing object keys are overwritten, including array values.
3. Save result to `patternlab-config.json`