### PR TITLE
Fix broken unit test(s)

### DIFF
--- a/test/files/_patterns/00-test/00-foo.md
+++ b/test/files/_patterns/00-test/00-foo.md
@@ -1,3 +1,6 @@
+---
+state: inreview
+---
 ## A Simple Include
 
 This pattern contains an include of `test-bar`. It also has this markdown file, which does not have frontmatter.

--- a/test/files/_patterns/00-test/01-bar.md
+++ b/test/files/_patterns/00-test/01-bar.md
@@ -1,5 +1,5 @@
 ---
-status: complete
+state: complete
 ---
 ## A Simple Bit of Markup
 

--- a/test/files/_patterns/00-test/03-styled-atom.md
+++ b/test/files/_patterns/00-test/03-styled-atom.md
@@ -1,3 +1,3 @@
 ---
-status: inprogress
+state: inprogress
 ---

--- a/test/lineage_hunter_tests.js
+++ b/test/lineage_hunter_tests.js
@@ -34,6 +34,9 @@ function createBasePatternLabObject() {
     paths: {
       source: {
         patterns: patterns_dir
+      },
+      public: {
+        patterns: './test/public/_patterns'
       }
     },
     outputFileSuffixes: {
@@ -48,6 +51,8 @@ function createBasePatternLabObject() {
   pl.config.debug = false;
   pl.patterns = [];
   pl.partials = {};
+  pl.patternGroups = {};
+  pl.subtypePatterns = {};
 
   return pl;
 }
@@ -266,17 +271,8 @@ tap.test('cascade_pattern_states sets the pattern state on any lineage patterns 
   //arrange
   var pl = createBasePatternLabObject();
 
-  var atomPattern = new of.Pattern('00-test/01-bar.mustache');
-  atomPattern.template = fs.readFileSync(pl.config.paths.source.patterns + '00-test/01-bar.mustache', 'utf8');
-  atomPattern.extendedTemplate = atomPattern.template;
-  atomPattern.patternState = "inreview";
-  pattern_assembler.addPattern(atomPattern, pl);
-
-  var consumerPattern = new of.Pattern('00-test/00-foo.mustache');
-  consumerPattern.template = fs.readFileSync(pl.config.paths.source.patterns + '00-test/00-foo.mustache', 'utf8');
-  consumerPattern.extendedTemplate = consumerPattern.template;
-  consumerPattern.patternState = "complete";
-  pattern_assembler.addPattern(consumerPattern, pl);
+  var atomPattern = pattern_assembler.load_pattern_iterative('00-test/01-bar.mustache', pl);
+  var consumerPattern = pattern_assembler.load_pattern_iterative('00-test/00-foo.mustache', pl);
 
   lineage_hunter.find_lineage(consumerPattern, pl);
 

--- a/test/markdown_parser_tests.js
+++ b/test/markdown_parser_tests.js
@@ -31,7 +31,7 @@ tap.test('parses pattern description block correctly when frontmatter present', 
 
     //assert
     test.equals(returnObject.markdown, '<h2>A Simple Bit of Markup</h2>\n<p>Foo cannot get simpler than bar, amiright?</p>\n');
-    test.equals(returnObject.status, 'complete');
+    test.equals(returnObject.state, 'complete');
   test.end();
 });
 
@@ -45,6 +45,6 @@ tap.test('parses frontmatter only when no markdown present', function (test) {
 
   //assert
   test.equals(returnObject.markdown, '');
-  test.equals(returnObject.status, 'inprogress');
+  test.equals(returnObject.state, 'inprogress');
   test.end();
 });


### PR DESCRIPTION
Fixed the broken Lineage Hunter unit test to load the patterns using the actual loader instead of trying to mock them out. The test MD files also seem to have been using `status` instead of `state`, so updated them as well (as per https://github.com/pattern-lab/the-spec/issues/16).