### PR TITLE
Config access for pattern engines

### DIFF
--- a/core/lib/pattern_engines.js
+++ b/core/lib/pattern_engines.js
@@ -62,7 +62,7 @@ function findEngineModulesInDirectory(dir) {
 
 const PatternEngines = Object.create({
 
-  loadAllEngines: function () {
+  loadAllEngines: function (patternLabConfig) {
     var self = this;
 
     // Try to load engines! We scan for engines at each path specified above. This
@@ -78,11 +78,17 @@ const PatternEngines = Object.create({
         const successMessage = chalk.green("good to go");
 
         try {
-          // give it a try! load 'er up. But not if we already have, of course.
+          // Give it a try! load 'er up. But not if we already have,
+          // of course.  Also pass the pattern lab config object into
+          // the engine's closure scope so it can know things about
+          // things.
           if (self[engineDiscovery.name]) {
             throw new Error("already loaded, skipping.");
           }
           self[engineDiscovery.name] = require(engineDiscovery.modulePath);
+          if (typeof self[engineDiscovery.name].usePatternLabConfig === 'function') {
+            self[engineDiscovery.name].usePatternLabConfig(patternLabConfig);
+          }
         } catch (err) {
           errorMessage = err.message;
         } finally {

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -182,7 +182,7 @@ const patternlab_engine = function (config) {
   const patternlab = {};
 
   patternlab.engines = patternEngines;
-  patternlab.engines.loadAllEngines();
+  patternlab.engines.loadAllEngines(config);
 
   const pattern_assembler = new pa();
   const pattern_exporter = new pe();


### PR DESCRIPTION
This is the simplest and least disruptive way I can think of to make engines configurable. If supported by each engine, call a function that injects the global pattern lab config into the closure scope of the engine so that engines can make configurable decisions.

@bramsmulders and I are thinking this is necessary to be able to configure the React engine -- the first use case being the ability to shut off client-side code generation if you don't need interactive components and / or are just using React components to make a static style guide. There should be some build speed benefit to doing that. 

This might also benefit the Handlebars engine, I seem to remember that it has some things you can configure.

See https://github.com/pattern-lab/patternengine-node-mustache/pull/8 for the Mustache implementation.