### PR TITLE
Attempt to parse the JSON to see if it is already well formed

### DIFF
--- a/core/lib/parameter_hunter.js
+++ b/core/lib/parameter_hunter.js
@@ -62,6 +62,14 @@ var parameter_hunter = function () {
     var values = [];
     var wrapper;
 
+    // attempt to parse the data incase it is already well formed JSON
+    try {
+      paramStringWellFormed = JSON.stringify(JSON.parse(pString));
+      return paramStringWellFormed;
+    } catch(err) {
+      console.log('Not valid JSON - will attempt to parse manually...');
+    }
+
     //replace all escaped double-quotes with escaped unicode
     paramString = paramString.replace(/\\"/g, '\\u0022');
 


### PR DESCRIPTION
Summary of changes:

Fixes an issue whereby injecting list items via pattern parameters into patterns would throw syntax errors. E.g:

```
{{> molecules-select-with-information(
    "sub-information": "Extra info about option 1",
    "options": [{
      "key": "1",
      "label": "Option 1"
    },
    {
      "key": "2",
      "label": "Option 2"
    },
    {
      "key": "3",
      "label": "Option 3"
    }],
    "value": "1"
  ) }}
```

Error thrown without fix:

```
[patternlab:build] There was an error parsing JSON for 02-organisms/visits/add-visit.mustache
[patternlab:build] SyntaxError: Unexpected token } in JSON at position 43
    at JSON.parse (<anonymous>)
    at /Users/cjpitt/development/the92club/node_modules/patternlab-node/core/lib/parameter_hunter.js:271:28
    at Array.forEach (native)
```