### PR TITLE
Title read from the markdown file. All markdown stored in currentPattern

### DIFF
--- a/core/lib/i18n.js
+++ b/core/lib/i18n.js
@@ -1,0 +1,16 @@
+/**
+
+  Very basic translation system
+
+*/
+
+"use strict";
+
+
+var i18n = function (config, keyword) {
+  var keyword = keyword.toLowerCase();
+  var translatedWord = config.i18n[keyword] !== undefined ? config.i18n[keyword] : keyword.charAt(0).toUpperCase() + keyword.slice(1);
+  return translatedWord;
+};
+
+module.exports = i18n;

--- a/core/lib/object_factory.js
+++ b/core/lib/object_factory.js
@@ -62,6 +62,7 @@ var Pattern = function (relPath, data, patternlab) {
   this.verbosePartial = this.subdir + '/' + this.fileName;
 
   this.isPattern = true;
+  this.joche = "Räksmörgås";
   this.isFlatPattern = this.patternGroup === this.patternSubGroup;
   this.patternState = '';
   this.template = '';

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -166,6 +166,11 @@ var pattern_assembler = function () {
         currentPattern.patternDescExists = true;
         currentPattern.patternDesc = markdownObject.markdown;
 
+
+        //Add all markdown to the currentPattern, including frontmatter
+        currentPattern.allMarkdown = markdownObject;
+
+
         //consider looping through all keys eventually. would need to blacklist some properties and whitelist others
         if (markdownObject.state) {
           currentPattern.patternState = markdownObject.state;
@@ -181,6 +186,9 @@ var pattern_assembler = function () {
         }
         if (markdownObject.tags) {
           currentPattern.tags = markdownObject.tags;
+        }
+        if (markdownObject.title) {
+          currentPattern.patternName = markdownObject.title;
         }
         if (markdownObject.links) {
           currentPattern.links = markdownObject.links;

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -26,7 +26,8 @@ var diveSync = require('diveSync'),
   ui_builder = new ui(),
   pe = require('./pattern_exporter'),
   pattern_exporter = new pe(),
-  PatternGraph = require('./pattern_graph').PatternGraph;
+  PatternGraph = require('./pattern_graph').PatternGraph,
+  i18n = require('./i18n.js');
 
 //register our log events
 plutils.log.on('error', msg => console.log(msg));
@@ -388,6 +389,11 @@ var patternlab_engine = function (config) {
 
     // stringify this data for individual pattern rendering and use on the styleguide
     // see if patternData really needs these other duped values
+    var pGroup = i18n(patternlab.config, pattern.patternGroup);
+    var pSubGroup = i18n(patternlab.config, pattern.patternSubGroup);
+
+
+
     pattern.patternData = JSON.stringify({
       cssEnabled: false,
       patternLineageExists: pattern.patternLineageExists,
@@ -398,12 +404,19 @@ var patternlab_engine = function (config) {
       lineageR: pattern.patternLineagesR,
       patternLineageEExists: pattern.patternLineageExists || pattern.patternLineageRExists,
       patternDesc: pattern.patternDescExists ? pattern.patternDesc : '',
+      // patternBreadcrumb:
+      //   pattern.patternGroup === pattern.patternSubGroup ? {
+      //     patternType: pattern.patternGroup
+      //   } : {
+      //     patternType: pattern.patternGroup,
+      //     patternSubtype: pattern.patternSubGroup
+      //   },
       patternBreadcrumb:
-        pattern.patternGroup === pattern.patternSubGroup ? {
-          patternType: pattern.patternGroup
+        pGroup === pSubGroup ? {
+          patternType: pGroup
         } : {
-          patternType: pattern.patternGroup,
-          patternSubtype: pattern.patternSubGroup
+          patternType: pGroup,
+          patternSubtype: pSubGroup
         },
       patternExtension: pattern.fileExtension.substr(1), //remove the dot because styleguide asset default adds it for us
       patternName: pattern.patternName,

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -250,7 +250,7 @@ var ui_builder = function () {
     if (createSubtypeViewAllVarient) {
       newSubTypeItem = {
         patternPartial: 'viewall-' + pattern.patternGroup + '-' + pattern.patternSubGroup,
-        patternName: 'View All',
+        patternName: (patternlab.config.i18n.viewall !== undefined ? patternlab.config.i18n.viewall :  "View all"),
         patternPath: encodeURI(pattern.flatPatternPath + '/index.html'),
         patternType: pattern.patternType,
         patternSubtype: pattern.patternSubtype,
@@ -288,7 +288,7 @@ var ui_builder = function () {
         //todo: it'd be nice if we could get this into createPatternSubTypeItem someday
         patternType.patternItems.push({
           patternPartial: 'viewall-' + pattern.patternGroup + '-all',
-          patternName: 'View All',
+          patternName: (patternlab.config.i18n.viewall !== undefined ? patternlab.config.i18n.viewall :  "View all"),
           patternPath: encodeURI(pattern.patternType + '/index.html'),
           order: -Number.MAX_SAFE_INTEGER
         });

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -10,6 +10,7 @@ var plutils = require('./utilities');
 var eol = require('os').EOL;
 var _ = require('lodash');
 var jsonCopy = require('./json_copy');
+var i18n = require('./i18n.js');
 
 var ui_builder = function () {
 
@@ -146,10 +147,13 @@ var ui_builder = function () {
    * @param pattern - the pattern to register
      */
   function addPatternType(patternlab, pattern) {
+    var fName = i18n(patternlab.config, pattern.patternGroup);
+
     patternlab.patternTypes.push(
       {
         patternTypeLC: pattern.patternGroup.toLowerCase(),
         patternTypeUC: pattern.patternGroup.charAt(0).toUpperCase() + pattern.patternGroup.slice(1),
+        patternTypeFN: fName,
         patternType: pattern.patternType,
         patternTypeDash: pattern.patternGroup, //todo verify
         patternTypeItems: []
@@ -201,9 +205,12 @@ var ui_builder = function () {
    * @param pattern - the pattern to register
      */
   function addPatternSubType(patternlab, pattern) {
+    var fName = i18n(patternlab.config, pattern.patternSubGroup);
+
     let newSubType = {
       patternSubtypeLC: pattern.patternSubGroup.toLowerCase(),
       patternSubtypeUC: pattern.patternSubGroup.charAt(0).toUpperCase() + pattern.patternSubGroup.slice(1),
+      patternSubtypeFN : fName,
       patternSubtype: pattern.patternSubType,
       patternSubtypeDash: pattern.patternSubGroup, //todo verify
       patternSubtypeItems: []
@@ -250,7 +257,7 @@ var ui_builder = function () {
     if (createSubtypeViewAllVarient) {
       newSubTypeItem = {
         patternPartial: 'viewall-' + pattern.patternGroup + '-' + pattern.patternSubGroup,
-        patternName: (patternlab.config.i18n.viewall !== undefined ? patternlab.config.i18n.viewall :  "View all"),
+        patternName: i18n(patternlab.config, "View all"),
         patternPath: encodeURI(pattern.flatPatternPath + '/index.html'),
         patternType: pattern.patternType,
         patternSubtype: pattern.patternSubtype,
@@ -288,7 +295,7 @@ var ui_builder = function () {
         //todo: it'd be nice if we could get this into createPatternSubTypeItem someday
         patternType.patternItems.push({
           patternPartial: 'viewall-' + pattern.patternGroup + '-all',
-          patternName: (patternlab.config.i18n.viewall !== undefined ? patternlab.config.i18n.viewall :  "View all"),
+          patternName: i18n(patternlab.config, "View all"),
           patternPath: encodeURI(pattern.patternType + '/index.html'),
           order: -Number.MAX_SAFE_INTEGER
         });


### PR DESCRIPTION
 Also adds the whole parsed markdown object to the pattern

Title in md-files Front Matter is now working as the documentation claims. The whole parsed md-file is now stored in currentPattern.allMarkdown. All Front Matter keys can be accessed in the patternSection.mustache. Example with the key 'preamble'

<h3 class="pl-preamble">{{ allMarkdown.preamble }}</h3>

