### PR TITLE
Title is now read from the markdown file, overrides file name. Also a…

### DIFF
--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -166,6 +166,11 @@ var pattern_assembler = function () {
         currentPattern.patternDescExists = true;
         currentPattern.patternDesc = markdownObject.markdown;
 
+
+        //Add all markdown to the currentPattern, including frontmatter
+        currentPattern.allMarkdown = markdownObject;
+
+
         //consider looping through all keys eventually. would need to blacklist some properties and whitelist others
         if (markdownObject.state) {
           currentPattern.patternState = markdownObject.state;
@@ -181,6 +186,9 @@ var pattern_assembler = function () {
         }
         if (markdownObject.tags) {
           currentPattern.tags = markdownObject.tags;
+        }
+        if (markdownObject.title) {
+          currentPattern.patternName = markdownObject.title;
         }
         if (markdownObject.links) {
           currentPattern.links = markdownObject.links;


### PR DESCRIPTION
…dds the whole parsed markdown object to the pattern

Title in md-files Front Matter is now working as the documentation claims. The whole parsed md-file is now stored in currentPattern.allMarkdown. All Front Matter keys, can be accessed in the patternSection.mustache with

<h3 class="pl-preamble">{{ allMarkdown.preamble }}</h3>

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #

Summary of changes:
