### PR TITLE
More helpful errors

### DIFF
--- a/core/lib/data_loader.js
+++ b/core/lib/data_loader.js
@@ -58,7 +58,7 @@ function loadDataFromFolder(dataFilesPath, excludeFileNames, fsDep) {
       mergeObject = _.merge(mergeObject, jsonData);
     }
     catch (err) {
-      throw new Error(`Error loading file: ${dataFile} - ${err.message}`);
+      throw new Error(`Error loading file: ${filePath} - ${err.message}`);
     }
   });
 

--- a/core/lib/data_loader.js
+++ b/core/lib/data_loader.js
@@ -20,7 +20,12 @@ function loadFile(dataFilesPath, fsDep) {
       dataFile = _.head(dataFiles);
 
     if (dataFile && fsDep.existsSync(path.resolve(dataFile))) {
-      return yaml.safeLoad(fsDep.readFileSync(path.resolve(dataFile), 'utf8'));
+      try {
+        return yaml.safeLoad(fsDep.readFileSync(path.resolve(dataFile), 'utf8'));
+      }
+      catch (err) {
+        throw new Error(`Error loading file: ${dataFile} - ${err.message}`);
+      }
     }
   }
 
@@ -48,8 +53,13 @@ function loadDataFromFolder(dataFilesPath, excludeFileNames, fsDep) {
   let mergeObject = {};
 
   dataFiles.forEach(function (filePath) {
-    let jsonData = yaml.safeLoad(fsDep.readFileSync(path.resolve(filePath), 'utf8'));
-    mergeObject = _.merge(mergeObject, jsonData);
+    try {
+      let jsonData = yaml.safeLoad(fsDep.readFileSync(path.resolve(filePath), 'utf8'));
+      mergeObject = _.merge(mergeObject, jsonData);
+    }
+    catch (err) {
+      throw new Error(`Error loading file: ${dataFile} - ${err.message}`);
+    }
   });
 
   return mergeObject;


### PR DESCRIPTION
Summary of changes:

Simple change to output the filename and error message of a failed parse to make the problem easier to find when there are multiple json files for a single pattern