### PR TITLE
Add support for pattern parameter links

### DIFF
--- a/core/lib/parameter_hunter.js
+++ b/core/lib/parameter_hunter.js
@@ -280,6 +280,8 @@ var parameter_hunter = function () {
           console.log(err);
         }
 
+        paramData = pattern_assembler.parse_data_links_specific(patternlab, paramData, pattern.patternPartial)
+
         var allData = plutils.mergeData(globalData, localData);
         allData = plutils.mergeData(allData, paramData);
 

--- a/test/parameter_hunter_tests.js
+++ b/test/parameter_hunter_tests.js
@@ -3,7 +3,6 @@
 var tap = require('tap');
 var pa = require('../core/lib/pattern_assembler');
 var Pattern = require('../core/lib/object_factory').Pattern;
-var CompileState = require('../core/lib/object_factory').CompileState;
 var PatternGraph = require('../core/lib/pattern_graph').PatternGraph;
 
 var fs = require('fs-extra');
@@ -59,12 +58,14 @@ function patternlabClosure() {
     },
     data: {
       description: 'Not a quote from a smart man',
-      link: {}
+      link: {
+        "molecules-single-comment": "01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html"
+      }
     },
     partials: {},
     graph: PatternGraph.empty()
-  }
-};
+  };
+}
 
 tap.test('parameter hunter finds and extends templates', function(test) {
   var currentPattern = currentPatternClosure();
@@ -399,6 +400,24 @@ tap.test('parameter hunter parses parameters containing html tags', function(tes
 
   parameter_hunter.find_parameters(currentPattern, patternlab);
   test.equals(currentPattern.extendedTemplate, '<p><strong>Single-quoted</strong></p><p><em>Double-quoted</em></p><p><strong class="foo" id=\'bar\'>With attributes</strong></p>');
+
+  test.end();
+});
+
+tap.test('parameter hunter expands links inside parameters', function (test) {
+  var currentPattern = currentPatternClosure();
+  var patternlab = patternlabClosure();
+  var parameter_hunter = new ph();
+
+  patternlab.patterns[0].template = '<a href="{{{ url }}}">{{ description }}</a>';
+  patternlab.patterns[0].extendedTemplate = patternlab.patterns[0].template;
+
+  currentPattern.template = "{{> molecules-single-comment(url: 'link.molecules-single-comment', description: 'Link to single comment') }}";
+  currentPattern.extendedTemplate = currentPattern.template;
+  currentPattern.parameteredPartials[0] = currentPattern.template;
+
+  parameter_hunter.find_parameters(currentPattern, patternlab);
+  test.equals(currentPattern.extendedTemplate, '<a href="01-molecules-06-components-02-single-comment/01-molecules-06-components-02-single-comment.html">Link to single comment</a>');
 
   test.end();
 });


### PR DESCRIPTION
Allow the use of link variables inside pattern parameters.

Addresses #688

Summary of changes:

The pattern parameters are run through `parse_data_links_specific` before rendering the pattern.