### PR TITLE
Removing redundant config.theme

### DIFF
--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -592,9 +592,6 @@ var ui_builder = function () {
     //plugins
     output += 'var plugins = ' + JSON.stringify(patternlab.plugins || []) + ';' + eol;
 
-    //theme
-    output += 'var theme = ' + JSON.stringify(patternlab.config.theme) + ';' + eol;
-
     //smaller config elements
     output += 'var defaultShowPatternInfo = ' + (patternlab.config.defaultShowPatternInfo ? patternlab.config.defaultShowPatternInfo : 'false') + ';' + eol;
     output += 'var defaultPattern = "' + (patternlab.config.defaultPattern ? patternlab.config.defaultPattern : 'all') + '";' + eol;


### PR DESCRIPTION
What was happening is that the `theme` object from `patternlab-config.json` was getting put into `styleguide/data/patternlab-data.js` in both `config.theme` and as `theme`. I think it makes more sense to have settings declared in `config` be inside of that object. 

Relates to https://github.com/pattern-lab/styleguidekit-assets-default/issues/91