### PR TITLE
fix(README): Add scoped package to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pattern Lab Node can be used different ways. Editions are **example** pairings o
 
 As of Pattern Lab Node 3.X, `patternlab-node` can run standalone, without the need for task runners like gulp or grunt.
 
-`npm install patternlab-node`
+`npm install @pattern-lab/patternlab-node`
 
 See [Usage](#Usage) for more information.
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses wrong package name post publish

Summary of changes:
 add scoped package name