### PR TITLE
patch fix for pattern-lab/patternlab-node/#737 starterkit postinstall

### DIFF
--- a/core/scripts/postinstall.js
+++ b/core/scripts/postinstall.js
@@ -19,9 +19,12 @@ try {
   var starterkit_manager = new sm(config);
   var foundStarterkits = starterkit_manager.detect_starterkits();
 
+  //todo - find a better solution for postinstall cleaning of starterkits
+  var clean = (typeof config.starterkitPostInstallClean !== 'undefined') ? config.starterkitPostInstallClean : true;
+
   //todo - enhance to support multiple kits with prompt for each or all
   if (foundStarterkits && foundStarterkits.length > 0) {
-    starterkit_manager.load_starterkit(foundStarterkits[0], true);
+    starterkit_manager.load_starterkit(foundStarterkits[0], clean);
   } else {
     console.log('No starterkits found to automatically load.');
   }

--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -56,6 +56,7 @@
   "patternExportPatternPartials": [],
   "patternExportDirectory": "./pattern_exports/",
   "cacheBust": true,
+  "starterkitPostInstallClean": false,
   "outputFileSuffixes": {
     "rendered": ".rendered",
     "rawTemplate": "",


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #737 

Summary of changes:

Added new config flag for starterkit postinstall
Added a new variable to either act as current, or read from config

This is the same as the CLI version of passing --clean