### PR TITLE
pseudopatterns polluting base patterns

### DIFF
--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -42,7 +42,7 @@ pseudopattern_hunter.prototype.find_pseudopatterns = function (currentPattern, p
       }
 
       //extend any existing data with variant data
-      variantFileData = _.merge(currentPattern.jsonFileData, variantFileData);
+      variantFileData = _.merge({}, currentPattern.jsonFileData, variantFileData);
 
       const variantName = pseudoPatterns[i].substring(pseudoPatterns[i].indexOf('~') + 1).split('.')[0];
       const variantFilePath = path.join(currentPattern.subdir, currentPattern.fileName + '~' + variantName + '.json');

--- a/core/lib/pseudopattern_hunter.js
+++ b/core/lib/pseudopattern_hunter.js
@@ -44,56 +44,10 @@ pseudopattern_hunter.prototype.find_pseudopatterns = function (currentPattern, p
       //extend any existing data with variant data
       variantFileData = _.merge(currentPattern.jsonFileData, variantFileData);
 
-      let variantName = pseudoPatterns[i].substring(pseudoPatterns[i].indexOf('~') + 1).split('.')[0];
-      let variantFilePath = path.join(currentPattern.subdir, currentPattern.fileName + '~' + variantName + '.json');
-      let lm = fs.statSync(variantFileFullPath);
-      let patternVariant = Pattern.create(variantFilePath, variantFileData, {
-        //use the same template as the non-variant
-        template: currentPattern.template,
-        fileExtension: currentPattern.fileExtension,
-        extendedTemplate: currentPattern.extendedTemplate,
-        isPseudoPattern: true,
-        basePattern: currentPattern,
-        stylePartials: currentPattern.stylePartials,
-        parameteredPartials: currentPattern.parameteredPartials,
-
-        // Only regular patterns are discovered during iterative walks
-        // Need to recompile on data change or template change
-        lastModified: Math.max(currentPattern.lastModified, lm.mtime),
-
-        // use the same template engine as the non-variant
-        engine: currentPattern.engine
-      }, patternlab);
-
-      changes_hunter.checkBuildState(patternVariant, patternlab);
-      patternlab.graph.add(patternVariant);
-      patternlab.graph.link(patternVariant, currentPattern);
-
-      //process the companion markdown file if it exists
-      pattern_assembler.parse_pattern_markdown(patternVariant, patternlab);
-
-      //find pattern lineage
-      lineage_hunter.find_lineage(patternVariant, patternlab);
-
-      //add to patternlab object so we can look these up later.
-      pattern_assembler.addPattern(patternVariant, patternlab);
-
-      //we want to do everything we normally would here, except instead read the pseudoPattern data
-      try {
-        var variantFileFullPath = path.resolve(paths.source.patterns, pseudoPatterns[i]);
-        var variantFileData = fs.readJSONSync(variantFileFullPath);
-      } catch (err) {
-        logger.warning(`There was an error parsing pseudopattern JSON for ${currentPattern.relPath}`);
-        logger.warning(err);
-      }
-
-      //extend any existing data with variant data
-      variantFileData = _.merge(currentPattern.jsonFileData, variantFileData);
-
-      variantName = pseudoPatterns[i].substring(pseudoPatterns[i].indexOf('~') + 1).split('.')[0];
-      variantFilePath = path.join(currentPattern.subdir, currentPattern.fileName + '~' + variantName + '.json');
-      lm = fs.statSync(variantFileFullPath);
-      patternVariant = Pattern.create(variantFilePath, variantFileData, {
+      const variantName = pseudoPatterns[i].substring(pseudoPatterns[i].indexOf('~') + 1).split('.')[0];
+      const variantFilePath = path.join(currentPattern.subdir, currentPattern.fileName + '~' + variantName + '.json');
+      const lm = fs.statSync(variantFileFullPath);
+      const patternVariant = Pattern.create(variantFilePath, variantFileData, {
         //use the same template as the non-variant
         template: currentPattern.template,
         fileExtension: currentPattern.fileExtension,

--- a/test/files/_patterns/00-test/03-styled-atom.json
+++ b/test/files/_patterns/00-test/03-styled-atom.json
@@ -1,0 +1,3 @@
+{
+  "message": "baseMessage"
+}

--- a/test/pseudopattern_hunter_tests.js
+++ b/test/pseudopattern_hunter_tests.js
@@ -46,11 +46,7 @@ tap.test('pseudpattern found and added as a pattern', function (test) {
   //arrange
   var pl = stubPatternlab();
 
-  var atomPattern = new Pattern('00-test/03-styled-atom.mustache');
-  atomPattern.template = fs.readFileSync(patterns_dir + '00-test/03-styled-atom.mustache', 'utf8');
-  atomPattern.extendedTemplate = atomPattern.template;
-  atomPattern.stylePartials = pattern_assembler.find_pattern_partials_with_style_modifiers(atomPattern);
-
+  var atomPattern = pattern_assembler.load_pattern_iterative('00-test/03-styled-atom.mustache', pl);
   pattern_assembler.addPattern(atomPattern, pl);
 
   //act
@@ -59,9 +55,24 @@ tap.test('pseudpattern found and added as a pattern', function (test) {
     //assert
     test.equals(patternCountBefore + 1, pl.patterns.length);
     test.equals(pl.patterns[1].patternPartial, 'test-styled-atom-alt');
-    test.equals(pl.patterns[1].extendedTemplate.replace(/\s\s+/g, ' ').replace(/\n/g, ' ').trim(), '<span class="test_base {{styleModifier}}"> {{message}} </span>');
     test.equals(JSON.stringify(pl.patterns[1].jsonFileData), JSON.stringify({"message": "alternateMessage"}));
     test.equals(pl.patterns[1].patternLink, '00-test-03-styled-atom-alt' + path.sep + '00-test-03-styled-atom-alt.html');
+  });
+});
+
+tap.test('pseudpattern does not pollute base pattern data', function (test) {
+  //arrange
+  var pl = stubPatternlab();
+
+  var atomPattern = pattern_assembler.load_pattern_iterative('00-test/03-styled-atom.mustache', pl);
+  pattern_assembler.addPattern(atomPattern, pl);
+
+  //act
+  var patternCountBefore = pl.patterns.length;
+  return pph.find_pseudopatterns(atomPattern, pl).then(() => {
+    //assert
+    test.equals(pl.patterns[0].patternPartial, 'test-styled-atom');
+    test.equals(JSON.stringify(pl.patterns[0].jsonFileData), JSON.stringify({"message": "baseMessage"}));
   });
 });
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #711

Summary of changes:

pseudopattern_hunter is performing a dangerous lodash merge against the base pattern data

``` js
//extend any existing data with variant data
variantFileData = _.merge(currentPattern.jsonFileData, variantFileData);
```

resulting in the [mutation](https://lodash.com/docs/4.17.4#merge) of the `currentPattern.jsonFileData object`.

Luckily, we get around this elsewhere by using `jsonCopy` on the merged objects. 

I also verified this now using starterkit-mustache-demo.


##### FIX NOT APPLIED, DASHBOARD

![image](https://user-images.githubusercontent.com/298435/32672290-1b2246c6-c610-11e7-8d9e-69aa4bf2a6fb.png)

(wrong data)

##### FIX NOT APPLIED, DASHBOARD ~ HACKED

![image](https://user-images.githubusercontent.com/298435/32672274-0c2cf6ca-c610-11e7-9554-7562cf74ab90.png)

(wrong data)

##### FIX APPLIED, DASHBOARD

![image](https://user-images.githubusercontent.com/298435/32672195-c9eb6602-c60f-11e7-93b7-e65ab40c64f0.png)

(correct default data)

##### FIX APPLIED, DASHBOARD ~ HACKED

![image](https://user-images.githubusercontent.com/298435/32672234-ec31d0e8-c60f-11e7-9826-6894ac039206.png)

(correct override data)



