### PR TITLE
Adding getDefaultConfig function to core

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -18,6 +18,7 @@ const cleanHtml = require('js-beautify').html;
 const inherits = require('util').inherits;
 const pm = require('./plugin_manager');
 const packageInfo = require('../../package.json');
+const defaultConfig = require('../../patternlab-config.json');
 const dataLoader = require('./data_loader')();
 const logger = require('./log');
 const jsonCopy = require('./json_copy');
@@ -269,7 +270,6 @@ class PatternLab {
 
 
   // info methods
-
   getVersion() {
     return this.package.version;
   }
@@ -420,6 +420,15 @@ function installPlugin(pluginName) {
   const plugin_manager = new pm(config, configPath);
 
   plugin_manager.install_plugin(pluginName);
+}
+
+/**
+ * Returns the standardized default config
+ *
+ * @return {object} Returns the object representation of the patternlab-config.json
+ */
+function getDefaultConfig() {
+  return defaultConfig
 }
 
 const patternlab_engine = function (config) {
@@ -730,7 +739,7 @@ const patternlab_engine = function (config) {
     version: function () {
       return patternlab.logVersion();
     },
-
+    
     /**
      * return current version
      *
@@ -869,5 +878,6 @@ const patternlab_engine = function (config) {
 patternlab_engine.build_pattern_data = buildPatternData;
 patternlab_engine.process_all_patterns_iterative = processAllPatternsIterative;
 patternlab_engine.process_all_patterns_recursive = processAllPatternsRecursive;
+patternlab_engine.getDefaultConfig = getDefaultConfig;
 
 module.exports = patternlab_engine;

--- a/test/patternlab_tests.js
+++ b/test/patternlab_tests.js
@@ -4,6 +4,7 @@ const tap = require('tap');
 const rewire = require("rewire");
 const _ = require('lodash');
 const fs = require('fs-extra');
+const defaultConfig = require('../patternlab-config.json');
 var config = require('./util/patternlab-config.json');
 
 var plEngineModule = rewire('../core/lib/patternlab');
@@ -79,5 +80,12 @@ tap.test('buildPatternData - can load json, yaml, and yml files', function(test)
   test.equals(dataResult.from_yml, "from_yml");
   test.equals(dataResult.from_yaml, "from_yaml");
   test.equals(dataResult.from_json, "from_json");
+  test.end();
+});
+
+tap.test('getDefaultConfig - should return the default config object', function(test) {
+  const requestedConfig = plEngineModule.getDefaultConfig();
+  test.type(requestedConfig, 'object');
+  test.equals(requestedConfig, defaultConfig);
   test.end();
 });


### PR DESCRIPTION
Addresses #749 

Summary of changes:
Adding a (static) function to the patternlab core to allow users to obtain a default config object