### PR TITLE
feat(patternlabjs): Remove build callback

### DIFF
--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -752,11 +752,10 @@ const patternlab_engine = function (config) {
     /**
      * build patterns, copy assets, and construct ui
      *
-     * @param {function} callback a function invoked when build is complete
      * @param {object} options an object used to control build behavior
      * @returns {Promise} a promise fulfilled when build is complete
      */
-    build: function (callback, options) {
+    build: function (options) {
       if (patternlab && patternlab.isBusy) {
         logger.info('Pattern Lab is busy building a previous run - returning early.');
         return Promise.resolve();
@@ -770,7 +769,7 @@ const patternlab_engine = function (config) {
         this.events.on('patternlab-pattern-change', () => {
           if (!patternlab.isBusy) {
             options.cleanPublic = false;
-            return this.build(callback, options);
+            return this.build(options);
           }
           return Promise.resolve();
         });
@@ -778,13 +777,12 @@ const patternlab_engine = function (config) {
         this.events.on('patternlab-global-change', () => {
           if (!patternlab.isBusy) {
             options.cleanPublic = true; //rebuild everything
-            return this.build(callback, options);
+            return this.build(options);
           }
           return Promise.resolve();
         });
 
         patternlab.isBusy = false;
-        callback();
       });
     },
 
@@ -800,11 +798,10 @@ const patternlab_engine = function (config) {
     /**
      * build patterns only, leaving existing public files intact
      *
-     * @param {function} callback a function invoked when build is complete
      * @param {object} options an object used to control build behavior
      * @returns {Promise} a promise fulfilled when build is complete
      */
-    patternsonly: function (callback, options) {
+    patternsonly: function (options) {
       if (patternlab && patternlab.isBusy) {
         logger.info('Pattern Lab is busy building a previous run - returning early.');
         return Promise.resolve();
@@ -812,7 +809,6 @@ const patternlab_engine = function (config) {
       patternlab.isBusy = true;
       return buildPatterns(options.cleanPublic).then(() => {
         patternlab.isBusy = false;
-        callback();
       });
     },
 
@@ -864,7 +860,7 @@ const patternlab_engine = function (config) {
      */
     serve: function (options) {
       options.watch = true;
-      return this.build(() => {}, options).then(function () {
+      return this.build(options).then(function () {
         serve(patternlab);
       });
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,15 @@
         }
       }
     },
+    "@pattern-lab/patternengine-node-mustache": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@pattern-lab/patternengine-node-mustache/-/patternengine-node-mustache-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-DVtGDv0zk2eGRFhdv1EBv6XY0rKCiD/t0bIiHpBBeIHI/vgHrC888FOrmY2Iq4jb3WLSjD66AE2Vhdt9QGWueg==",
+      "requires": {
+        "fs-extra": "0.30.0",
+        "mustache": "2.3.0"
+      }
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -2088,6 +2097,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mustache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
+      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
     },
     "mz": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "3.0.0-alpha.4",
   "main": "./core/lib/patternlab.js",
   "dependencies": {
+    "@pattern-lab/live-server": "^1.3.2",
+    "@pattern-lab/patternengine-node-mustache": "^2.0.0-alpha.1",
     "async": "^2.1.2",
     "chalk": "^1.1.3",
     "chokidar": "^1.7.0",
@@ -15,7 +17,6 @@
     "graphlib": "^2.1.1",
     "js-beautify": "^1.6.3",
     "js-yaml": "^3.6.1",
-    "@pattern-lab/live-server": "^1.3.2",
     "lodash": "~4.13.1",
     "markdown-it": "^6.0.1",
     "node-fetch": "^1.6.0",

--- a/test/patternlab_tests.js
+++ b/test/patternlab_tests.js
@@ -68,9 +68,9 @@ tap.test('buildPatterns - should replace data link even when pattern parameter p
   var pl = new plEngineModule(config);
 
   //act
-  pl.build(function() {
+  pl.build(true).then(() => {
     test.end();
-  }, true);
+  });
 });
 
 tap.test('buildPatternData - can load json, yaml, and yml files', function(test) {


### PR DESCRIPTION
Addresses #751

Summary of changes:

Removes the first parameter (a callback) in the `build` and `patternsonly` methods, as they return promises anyway
