### PR TITLE
Fixes dir duplication when serving files

### DIFF
--- a/core/lib/asset_copy.js
+++ b/core/lib/asset_copy.js
@@ -89,7 +89,7 @@ const asset_copier = () => {
 
         //watch for changes and copy
         assetWatcher.on('addDir', (p) => {
-          const destination = path.resolve(basePath, dir.public + '/' + path.basename(p));
+          const destination = path.resolve(basePath, dir.public);
           copyFile(p, destination, copyOptions);
         }).on('add', (p) => {
           const destination = path.resolve(basePath, dir.public + '/' + path.basename(p));


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #762 

Summary of changes:
Removed the basename append in `addDir` watcher