### PR TITLE
Use patterns created by processMetaPattern for rendering

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -195,14 +195,6 @@ const patternlab_module = function (config) {
         //cascade any patternStates
         lineage_hunter.cascade_pattern_states(patternlab);
 
-        //set pattern-specific header if necessary
-        let head;
-        if (patternlab.userHead) {
-          head = patternlab.userHead;
-        } else {
-          head = patternlab.header;
-        }
-
         //set the pattern-specific header by compiling the general-header with data, and then adding it to the meta header
         return render(Pattern.createEmpty({extendedTemplate: patternlab.header}), {
           cacheBuster: patternlab.cacheBuster
@@ -239,7 +231,7 @@ const patternlab_module = function (config) {
           //render all patterns last, so lineageR works
           return patternsToBuild
             .reduce((previousPromise, pattern) => {
-              return previousPromise.then(() => patternlab.renderSinglePattern(pattern, head));
+              return previousPromise.then(() => patternlab.renderSinglePattern(pattern));
             }, Promise.resolve())
             .then(() => {
               // Saves the pattern graph when all files have been compiled

--- a/core/lib/buildFooter.js
+++ b/core/lib/buildFooter.js
@@ -31,7 +31,7 @@ module.exports = function (patternlab, patternPartial) {
     }
     allFooterData.patternLabFoot = footerPartial;
 
-    return render(Pattern.createEmpty({extendedTemplate: patternlab.userFoot}), allFooterData);
+    return render(patternlab.userFoot, allFooterData);
   }).catch(reason => {
     console.log(reason);
     logger.error('Error building buildFooterHTML');

--- a/core/lib/patternlab.js
+++ b/core/lib/patternlab.js
@@ -275,7 +275,7 @@ module.exports = class PatternLab {
     }
   }
 
-  renderSinglePattern(pattern, head) {
+  renderSinglePattern(pattern) {
     // Pattern does not need to be built and recompiled more than once
     if (!pattern.isPattern || pattern.compileState === CompileState.CLEAN) {
       return Promise.resolve(false);
@@ -309,10 +309,12 @@ module.exports = class PatternLab {
     ///////////////
 
     //re-rendering the headHTML each time allows pattern-specific data to influence the head of the pattern
-    pattern.header = head;
-
-    // const headHTML
-    const headPromise = render(Pattern.createEmpty({extendedTemplate: pattern.header}), allData);
+    let headPromise;
+    if (this.userHead) {
+      headPromise = render(this.userHead, allData);
+    } else {
+      headPromise = render(Pattern.createEmpty({ extendedTemplate: this.header }), allData);
+    }
 
     ///////////////
     // PATTERN
@@ -388,7 +390,7 @@ module.exports = class PatternLab {
       allFooterData = _.merge(allFooterData, pattern.jsonFileData);
       allFooterData.patternLabFoot = footerPartial;
 
-      return render(Pattern.createEmpty({extendedTemplate: self.userFoot}), allFooterData).then(footerHTML => {
+      return render(self.userFoot, allFooterData).then(footerHTML => {
 
         ///////////////
         // WRITE FILES

--- a/core/lib/processMetaPattern.js
+++ b/core/lib/processMetaPattern.js
@@ -16,7 +16,7 @@ module.exports = function (fileName, metaType, patternlab) {
   metaPattern.isPattern = false;
   metaPattern.isMetaPattern = true;
   return decompose(metaPattern, patternlab, true).then(() => {
-    patternlab[metaType] = metaPattern.extendedTemplate;
+    patternlab[metaType] = metaPattern;
   }).catch(reason => {
     logger.warning(`Could not find the user-editable template ${fileName}, currently configured to be at ${patternlab.config.paths.source.meta}. Your configured path may be incorrect (check paths.source.meta in your config file), the file may have been deleted, or it may have been left in the wrong place during a migration or update.`);
     logger.warning(reason);

--- a/core/lib/ui_builder.js
+++ b/core/lib/ui_builder.js
@@ -639,7 +639,7 @@ const ui_builder = function () {
       const headFootData = patternlab.data;
       headFootData.patternLabHead = headerPartial;
       headFootData.cacheBuster = patternlab.cacheBuster;
-      return render(Pattern.createEmpty({extendedTemplate: patternlab.userHead}), headFootData);
+      return render(patternlab.userHead, headFootData);
     }).catch(reason => {
       console.log(reason);
       logger.error('error during header render()');
@@ -652,7 +652,7 @@ const ui_builder = function () {
     }).then(footerPartial => {
       const headFootData = patternlab.data;
       headFootData.patternLabFoot = footerPartial;
-      return render(Pattern.createEmpty({extendedTemplate: patternlab.userFoot}), headFootData);
+      return render(patternlab.userFoot, headFootData);
     }).catch(reason => {
       console.log(reason);
       logger.error('error during footer render()');


### PR DESCRIPTION
Use patterns created by processMetaPattern for rendering (instead of empty ones).

Addresses #766 

Summary of changes:
1. Set patternlab.userHead and patternlab.userFoot to their full patterns instead of just the extendedTemplate.

2. Replace empty patterns in render calls with full patterns.
