### PR TITLE
fix(loadPattern): Check proper data file paths for modification

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -373,7 +373,6 @@ const patternlab_module = function(config) {
 
           this.events.on('patternlab-pattern-change', () => {
             if (!patternlab.isBusy) {
-              options.cleanPublic = false;
               return this.build(options);
             }
             return Promise.resolve();
@@ -381,8 +380,9 @@ const patternlab_module = function(config) {
 
           this.events.on('patternlab-global-change', () => {
             if (!patternlab.isBusy) {
-              options.cleanPublic = true; //rebuild everything
-              return this.build(options);
+              return this.build(
+                Object.assign({}, options, { cleanPublic: true }) // rebuild everything
+              );
             }
             return Promise.resolve();
           });

--- a/core/lib/changes_hunter.js
+++ b/core/lib/changes_hunter.js
@@ -1,6 +1,8 @@
 'use strict';
-const fs = require('fs-extra');
 const CompileState = require('./object_factory').CompileState;
+
+//this is mocked in unit tests
+let fs = require('fs-extra'); //eslint-disable-line prefer-const
 
 /**
  * For detecting changed patterns.
@@ -73,7 +75,7 @@ ChangesHunter.prototype = {
    * @param {string} file
    */
   checkLastModified: function(currentPattern, file) {
-    if (file) {
+    if (file && fs.pathExistsSync(file)) {
       try {
         const stat = fs.statSync(file);
 

--- a/core/lib/loadPattern.js
+++ b/core/lib/loadPattern.js
@@ -178,7 +178,15 @@ module.exports = function(relPath, patternlab) {
   //find any pattern parameters that may be in the current pattern
   currentPattern.parameteredPartials = currentPattern.findPartialsWithPatternParameters();
 
-  [templatePath, jsonFilename, listJsonFileName].forEach(file => {
+  [
+    templatePath,
+    `${jsonFilename}.json`,
+    `${jsonFilename}.yml`,
+    `${jsonFilename}.yaml`,
+    `${listJsonFileName}.json`,
+    `${listJsonFileName}.yml`,
+    `${listJsonFileName}.yaml`,
+  ].forEach(file => {
     changes_hunter.checkLastModified(currentPattern, file);
   });
 

--- a/test/changes_hunter_tests.js
+++ b/test/changes_hunter_tests.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const tap = require('tap');
+const rewire = require('rewire');
+
+const ch = rewire('../core/lib/changes_hunter');
+
+const fsMock = {
+  statSync: function() {
+    return {
+      mtime: {
+        getTime: () => {
+          console.log('????');
+          return 100;
+        },
+      },
+    };
+  },
+  pathExistsSync: () => {
+    return true;
+  },
+};
+
+//set our mocks in place of usual require()
+ch.__set__({
+  fs: fsMock,
+});
+
+const changes_hunter = new ch();
+
+tap.test('checkLastModified - sets lastModified to fileTime ', function(test) {
+  //arrange
+  const mockPattern = { lastModified: 0 };
+  //act
+  changes_hunter.checkLastModified(mockPattern, {});
+
+  //assert
+  test.equals(mockPattern.lastModified, 100);
+  test.end();
+});
+
+tap.test(
+  'checkLastModified - does not alter pattern if file not found',
+  function(test) {
+    //arrange
+    const mockPattern = { lastModified: 1010 };
+    //act
+    changes_hunter.checkLastModified(mockPattern, null);
+
+    //assert
+    test.equals(mockPattern.lastModified, 1010);
+    test.end();
+  }
+);
+
+tap.test(
+  'checkLastModified - uses pattern.lastModified if greater than file time',
+  function(test) {
+    //arrange
+    const mockPattern = { lastModified: 101 };
+    //act
+    changes_hunter.checkLastModified(mockPattern, {});
+
+    //assert
+    test.equals(mockPattern.lastModified, 101);
+    test.end();
+  }
+);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #790 

Summary of changes:

Explicitly append the known data filenames when searching for changes.

I think this was introduced in https://github.com/pattern-lab/patternlab-node/pull/634 when the extension was no longer used with `data_loader` (😎) but removed it from the caller (:bug:)

