### PR TITLE
Fix watches and event listener leaks

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -372,14 +372,14 @@ const patternlab_module = function(config) {
           copier()
             .copyAndWatch(patternlab.config.paths, patternlab, options)
             .then(() => {
-              this.events.on('patternlab-pattern-change', () => {
+              this.events.once(events.PATTERNLAB_PATTERN_CHANGE, f => {
                 if (!patternlab.isBusy) {
                   return this.build(options);
                 }
                 return Promise.resolve();
               });
 
-              this.events.on('patternlab-global-change', () => {
+              this.events.once(events.PATTERNLAB_GLOBAL_CHANGE, () => {
                 if (!patternlab.isBusy) {
                   return this.build(
                     Object.assign({}, options, { cleanPublic: true }) // rebuild everything

--- a/core/index.js
+++ b/core/index.js
@@ -372,7 +372,7 @@ const patternlab_module = function(config) {
           copier()
             .copyAndWatch(patternlab.config.paths, patternlab, options)
             .then(() => {
-              this.events.once(events.PATTERNLAB_PATTERN_CHANGE, f => {
+              this.events.once(events.PATTERNLAB_PATTERN_CHANGE, () => {
                 if (!patternlab.isBusy) {
                   return this.build(options);
                 }

--- a/core/lib/copier.js
+++ b/core/lib/copier.js
@@ -89,7 +89,7 @@ const copier = () => {
     return Promise.all(copyPromises).then(() => {
       //we need to special case patterns/**/*.md|.json|.pattern-extensions as well as the global structures
       if (options.watch) {
-        watchPatternLabFiles(patternlab, assetDirectories, basePath);
+        return watchPatternLabFiles(patternlab, assetDirectories, basePath);
       }
     });
   };

--- a/core/lib/copier.js
+++ b/core/lib/copier.js
@@ -91,6 +91,7 @@ const copier = () => {
       if (options.watch) {
         return watchPatternLabFiles(patternlab, assetDirectories, basePath);
       }
+      return Promise.resolve();
     });
   };
 

--- a/core/lib/serve.js
+++ b/core/lib/serve.js
@@ -1,6 +1,8 @@
 'use strict';
 const path = require('path');
 const liveServer = require('@pattern-lab/live-server');
+
+const events = require('./events');
 const logger = require('./log');
 
 const serve = patternlab => {
@@ -25,7 +27,7 @@ const serve = patternlab => {
   );
 
   // watch for asset changes, and reload appropriately
-  patternlab.events.on('patternlab-asset-change', data => {
+  patternlab.events.on(events.PATTERNLAB_PATTERN_ASSET_CHANGE, data => {
     if (serverReady) {
       if (data.file.indexOf('css') > -1) {
         liveServer.refreshCSS();
@@ -36,7 +38,7 @@ const serve = patternlab => {
   });
 
   //watch for pattern changes, and reload
-  patternlab.events.on('patternlab-pattern-change', () => {
+  patternlab.events.on(events.PATTERNLAB_PATTERN_CHANGE, () => {
     if (serverReady) {
       liveServer.reload();
     }

--- a/core/lib/watchPatternLabFiles.js
+++ b/core/lib/watchPatternLabFiles.js
@@ -74,6 +74,10 @@ const watchPatternLabFiles = (
   _.each(patternWatches, patternWatchPath => {
     logger.debug(`Pattern Lab is watching ${patternWatchPath} for changes`);
 
+    if (patternlab.watchers[patternWatchPath]) {
+      patternlab.watchers[patternWatchPath].close();
+    }
+
     const patternWatcher = chokidar.watch(path.resolve(patternWatchPath), {
       ignored: /(^|[\/\\])\../,
       ignoreInitial: true,
@@ -81,6 +85,7 @@ const watchPatternLabFiles = (
         stabilityThreshold: 200,
         pollInterval: 100,
       },
+      persistent: !watchOnce,
     });
 
     //watch for changes and rebuild
@@ -100,6 +105,8 @@ const watchPatternLabFiles = (
           file: p,
         });
       });
+
+    patternlab.watchers[patternWatchPath] = patternWatcher;
   });
 
   logger.info(
@@ -107,6 +114,7 @@ const watchPatternLabFiles = (
       assetDirectories.source.root
     }`
   );
+  return Promise.resolve();
 };
 
 module.exports = watchPatternLabFiles;

--- a/test/watchPatternLabFiles_tests.js
+++ b/test/watchPatternLabFiles_tests.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const _ = require('lodash');
+const tap = require('tap');
+const rewire = require('rewire');
+const path = require('path');
+
+const util = require('./util/test_utils.js');
+const watchPatternLabFiles = rewire('../core/lib/watchPatternLabFiles');
+
+const patterns_dir = './test/files/_patterns';
+
+tap.test(
+  'watchPatternLabFiles - adds watcher to patternlab.watchers for given patternWatchPath',
+  test => {
+    const pl = util.fakePatternLab(patterns_dir, {
+      watchers: [],
+      engines: {},
+    });
+
+    pl.engines.getSupportedFileExtensions = () => {
+      return ['.mustache'];
+    };
+
+    watchPatternLabFiles(
+      pl,
+      {
+        source: {
+          data: '_data',
+          meta: '_meta',
+          patterns: 'patterns',
+        },
+      },
+      '/foo',
+      true
+    );
+
+    // should have two for _data and _meta
+    // should have five for '.json', '.yml', '.yaml', '.md' and '.mustache'
+    test.equals(Object.keys(pl.watchers).length, 7);
+
+    test.end();
+  }
+);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #793 

Summary of changes:

* Registers watches so they may be cleaned up on subsequent builds
* Only listens for events once, removing duplicative calls 
