### PR TITLE
Split out help logs into an external function

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -17,6 +17,7 @@ const copy = require('recursive-copy');
 const path = require('path');
 const updateNotifier = require('update-notifier');
 
+const help = require('./lib/help');
 const events = require('./lib/events');
 const logger = require('./lib/log');
 const PatternGraph = require('./lib/pattern_graph').PatternGraph;
@@ -58,89 +59,6 @@ const patternlab_module = function(config) {
   const PatternLab = require('./lib/patternlab');
   const patternlab = new PatternLab(config);
   const paths = patternlab.config.paths;
-
-  function help() {
-    logger.info('');
-
-    logger.info('Pattern Lab Node v' + patternlab.package.version);
-
-    logger.info('');
-    logger.info('Usage: patternlab.<FUNCTION_NAME>()');
-    logger.info('');
-
-    logger.info(' build');
-    logger.info(
-      '   > builds patterns, copies assets, and constructs ui into config.paths.public'
-    );
-    logger.info('');
-
-    logger.info(' patternsonly');
-    logger.info(
-      '   > builds patterns only, leaving existing public files intact'
-    );
-    logger.info('');
-
-    logger.info(' version');
-    logger.info('   > logs current version');
-    logger.info('');
-
-    logger.info(' v');
-    logger.info('   > return current version as a string');
-    logger.info('');
-
-    logger.info(' help');
-    logger.info(
-      '   > logs more information about patternlab-node, pattern lab in general, and where to report issues.'
-    );
-    logger.info('');
-
-    logger.info(' liststarterkits');
-    logger.info(
-      '   > fetches starterkit repos from pattern-lab github org that contain "starterkit" in their name'
-    );
-    logger.info('');
-
-    logger.info(' loadstarterkit');
-    logger.info(
-      '   > loads starterkit already available via `node_modules/` into config.paths.source/*'
-    );
-    logger.info(
-      '   > NOTE: Overwrites existing content, and only cleans out existing directory if --clean=true argument is passed.'
-    );
-    logger.info(
-      '   > NOTE: In most cases, `npm install starterkit-name` will precede this call.'
-    );
-    logger.info('   > parameters:');
-    logger.info('      kit:string ');
-    logger.info('      > the name of the starter kit to load');
-    logger.info('      clean:bool ');
-    logger.info(
-      '      > whether or not to remove all files from config.paths.source/ prior to load'
-    );
-    logger.info('   > example:');
-    logger.info(
-      '    `patternlab.loadstarterkit("starterkit-mustache-demo", true)'
-    );
-    logger.info('');
-
-    // installplugin
-    // serve
-    // getSupportedTemplateExtensions
-    // events
-    // getDefaultConfig
-
-    logger.info('===============================');
-    logger.info('');
-    logger.info('Visit http://patternlab.io/ for more info about Pattern Lab');
-    logger.info(
-      'Visit https://github.com/pattern-lab/patternlab-node/issues to open an issue.'
-    );
-    logger.info(
-      'Visit https://github.com/pattern-lab/patternlab-node/wiki to view the changelog, roadmap, and other info.'
-    );
-    logger.info('');
-    logger.info('===============================');
-  }
 
   /**
    * If a graph was serialized and then {@code deletePatternDir == true}, there is a mismatch in the
@@ -438,7 +356,7 @@ const patternlab_module = function(config) {
      * @returns {void} pattern lab API usage, as console output
      */
     help: function() {
-      help();
+      logger.info(help(patternlab.package.version));
     },
 
     /**

--- a/packages/core/src/lib/help.js
+++ b/packages/core/src/lib/help.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * @function help
+ * @desc A small helper function returning the man page string
+ * @param {string} version - The version to include in the string literal
+ * @return {string} - The man string
+ */
+const help = version => `
+  Pattern Lab Node v${version}
+
+  Usage: patternlab.<FUNCTION>()
+
+  Functions:
+
+    build                    Builds patterns, copies assets, and constructs ui into config.paths.public
+    patternsonly             Builds patterns only, leaving existing public files intact
+    liststarterkits          Fetches starterkit repos from pattern-lab github org
+    loadstarterkit           Loads starterkit already available via node_modules/ into config.paths.source/*
+                             NOTE: In most cases, npm install starterkit-name will precede this call.
+      Parameters:
+        kit                  The name of the starter kit to load (string)
+        clean                Whether or not to remove all files from config.paths.source/ prior to load (bool)
+                             NOTE: Overwrites existing content. Prunes existing directory if --clean=true argument is passed.
+    version                  Logs current version to stdout
+    v                        Return current version as a string
+
+  ===============================
+  - More info about Pattern Lab: http://patternlab.io/
+  - Open an issue: https://github.com/pattern-lab/patternlab-node/issues
+  - View the changelog, roadmap, and other info: https://github.com/pattern-lab/patternlab-node/wiki
+  ===============================`;
+module.exports = help;

--- a/packages/core/test/help_tests.js
+++ b/packages/core/test/help_tests.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const tap = require('tap');
+const help = require('../src/lib/help');
+
+tap.test('help - includes passed in version number', function(
+  test
+) {
+  //arrange
+  const version = '⚡';
+
+  //act
+  const result = help(version).trim();
+
+  //assert
+  test.ok(result.startsWith(`Pattern Lab Node v${version}`));
+  test.end();
+});


### PR DESCRIPTION
Summary of changes:
- Split out `help`function from `core/src/index.js` to make it more versatile and uncluttered the main file