### PR TITLE
Fix/data leak

### DIFF
--- a/packages/core/src/lib/data_loader.js
+++ b/packages/core/src/lib/data_loader.js
@@ -8,14 +8,14 @@ const glob = require('glob'),
 /**
  * Loads a single config file, in yaml/json format.
  *
- * @param dataFilesPath - leave off the file extension.
+ * @param dataFilePath - leave off the file extension.
  * @param fsDep
  * @returns {*}
  */
-function loadFile(dataFilesPath, fsDep) {
-  const dataFilesFullPath = dataFilesPath + '{.,[!-]*.}{json,yml,yaml}';
+function loadFile(dataFilePath, fsDep) {
+  const dataFilesFullPath = `${dataFilePath}.{json,yml,yaml}`;
 
-  if (dataFilesPath) {
+  if (dataFilePath) {
     const dataFiles = glob.sync(dataFilesFullPath),
       dataFile = _.head(dataFiles);
 

--- a/packages/core/src/lib/loadPattern.js
+++ b/packages/core/src/lib/loadPattern.js
@@ -142,7 +142,7 @@ module.exports = function(relPath, patternlab) {
     listJsonFileName = path.resolve(
       patternsPath,
       currentPattern.subdir,
-      currentPattern.fileName + '.listitems'
+      `${currentPattern.fileName}.listitems`
     );
     const listItemsData = dataLoader.loadDataFromFile(listJsonFileName, fs);
 

--- a/packages/core/test/loadPattern_tests.js
+++ b/packages/core/test/loadPattern_tests.js
@@ -90,3 +90,20 @@ tap.test('loadPattern - adds a markdown pattern if encountered', function(
   test.equals(result, subTypePattern);
   test.end();
 });
+
+tap.test(
+  'loadPattern - does not load pseudopattern data on the base pattern',
+  test => {
+    //arrange
+    const patternlab = util.fakePatternLab(patterns_dir);
+    const basePatternPath = path.join('00-test', '474-pseudomodifier.mustache');
+
+    //act
+    const result = loadPattern(basePatternPath, patternlab);
+
+    //assert
+    test.same(result.jsonFileData, {});
+
+    test.end();
+  }
+);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #821 

Summary of changes:

Do not add wildcards to the data_loader glob. I can understand wanting to do that to support `_data/*.json` minus `listitems`, but not for individual patterns. This bug is not present if a file like `button.json` exists (see #821 for what I mean). Since starterkit-mustache-demo usually has json files for base patterns too, it was less likely to be seen until now.