### PR TITLE
Fix incremental build on data change

### DIFF
--- a/core/lib/data_loader.js
+++ b/core/lib/data_loader.js
@@ -5,6 +5,10 @@ const glob = require('glob'),
   path = require('path'),
   yaml = require('js-yaml');
 
+function assembleFilename(dataFilesPath) {
+  return glob.sync(dataFilesPath + '{.,[!-]*.}{json,yml,yaml}')[0];
+}
+
 /**
  * Loads a single config file, in yaml/json format.
  *
@@ -13,15 +17,10 @@ const glob = require('glob'),
  * @returns {*}
  */
 function loadFile(dataFilesPath, fsDep) {
-  const dataFilesFullPath = dataFilesPath + '{.,[!-]*.}{json,yml,yaml}';
+  const dataFile = assembleFilename(dataFilesPath);
 
-  if (dataFilesPath) {
-    const dataFiles = glob.sync(dataFilesFullPath),
-      dataFile = _.head(dataFiles);
-
-    if (dataFile && fsDep.existsSync(path.resolve(dataFile))) {
-      return yaml.safeLoad(fsDep.readFileSync(path.resolve(dataFile), 'utf8'));
-    }
+  if (dataFile && fsDep.existsSync(path.resolve(dataFile))) {
+    return yaml.safeLoad(fsDep.readFileSync(path.resolve(dataFile), 'utf8'));
   }
 
   return null;
@@ -57,6 +56,7 @@ function loadDataFromFolder(dataFilesPath, excludeFileNames, fsDep) {
 
 module.exports = function configFileLoader() {
   return {
+    assembleFilename: assembleFilename,
     loadDataFromFile: loadFile,
     loadDataFromFolder: loadDataFromFolder
   };

--- a/core/lib/pattern_assembler.js
+++ b/core/lib/pattern_assembler.js
@@ -372,7 +372,10 @@ var pattern_assembler = function () {
     //find any pattern parameters that may be in the current pattern
     currentPattern.parameteredPartials = currentPattern.findPartialsWithPatternParameters();
 
-    [templatePath, jsonFilename, listJsonFileName].forEach(file => {
+    // Get path of config file with extension
+    const dataFilename = dataLoader.assembleFilename(jsonFilename);
+
+    [templatePath, dataFilename, listJsonFileName].forEach(file => {
       changes_hunter.checkLastModified(currentPattern, file);
     });
 

--- a/test/data_loader_tests.js
+++ b/test/data_loader_tests.js
@@ -2,12 +2,19 @@
 
 const tap = require('tap');
 
-tap.test('loadDataFromFile - Load ', function(test){
-  const fs = require('fs-extra'),
-    dataLoader = require('../core/lib/data_loader')(),
-    data_dir = './test/files/_data/';
+const dataLoader = require('../core/lib/data_loader')();
+const data_dir = './test/files/_data/';
 
-  let data = dataLoader.loadDataFromFile(data_dir + 'foo', fs);
+tap.test('loadDataFromFile - Load ', function(test){
+  const fs = require('fs-extra');
+  const data = dataLoader.loadDataFromFile(data_dir + 'foo', fs);
   test.equals(data.foo, 'bar');
+  test.end();
+});
+
+tap.test('assembleFilename - Load ', function(test){
+  const dataFilesPath = data_dir + 'data';
+  const dataFilePath = dataLoader.assembleFilename(dataFilesPath);
+  test.equals(dataFilePath, dataFilesPath + '.json');
   test.end();
 });


### PR DESCRIPTION
We had this issue with v2.12.0: `jsonFilename` was missing the data file extension ('.json', '.yaml', '.yml'). Because of that the last modified check did not update the patterns compile state if the data file changed.

Since this would have to be a patch release (`v2.12.1`) is it ok that this does not target the dev branch?