### PR TITLE
fix(install): add break statements to install edition command

### DIFF
--- a/packages/cli/bin/install-edition.js
+++ b/packages/cli/bin/install-edition.js
@@ -29,6 +29,7 @@ const installEdition = (edition, config) =>
           path.resolve('./node_modules', edition, 'gulpfile.js'),
           path.resolve(sourceDir, '../', 'gulpfile.js')
         );
+        break;
       }
       case '@pattern-lab/edition-node': {
         const scriptsJSON = {
@@ -40,6 +41,7 @@ const installEdition = (edition, config) =>
         };
         pkg.scripts = Object.assign({}, pkg.scripts || {}, scriptsJSON);
         yield writeJsonAsync('./package.json', pkg, { spaces: 2 });
+        break;
       }
     }
     return config;


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #875

Summary of changes:

Adds break statements to CLI edition installation
