### PR TITLE
fix(package): Allow .json extension on annotations file (issue #836)

### DIFF
--- a/packages/core/src/lib/annotationExporter.js
+++ b/packages/core/src/lib/annotationExporter.js
@@ -6,43 +6,49 @@ const _ = require('lodash');
 const mp = require('./markdown_parser');
 const logger = require('./log');
 
-const annotations_exporter = function(pl) {
+const annotationExporter = function(pl) {
   const paths = pl.config.paths;
-  let oldAnnotations;
 
   /**
    * Parses JS annotations.
    * @returns array of comments that used to be wrapped in raw JS
    */
-  function parseAnnotationsJS() {
+  function parseAnnotationsJSON() {
+    const jsonPath = path.resolve(paths.source.annotations, 'annotations.json');
+    let annotations;
+
     //attempt to read the file
     try {
-      oldAnnotations = fs.readFileSync(
-        path.resolve(paths.source.annotations, 'annotations.js'),
-        'utf8'
-      );
+      if (fs.pathExistsSync(jsonPath)) {
+        //read the new file
+        annotations = fs.readFileSync(jsonPath, 'utf8');
+      } else {
+        //read the old file
+        const jsPath = path.resolve(paths.source.annotations, 'annotations.js');
+
+        annotations = fs
+          .readFileSync(jsPath, 'utf8')
+          .replace(/^\s*var comments ?= ?/, '')
+          .replace(/};\s*$/, '}');
+
+        logger.info(
+          `Please convert ${jsPath} to JSON and rename it annotations.json.`
+        );
+      }
     } catch (ex) {
       logger.debug(
-        `annotations.js file missing from ${
+        `annotations.json file missing from ${
           paths.source.annotations
         }. This may be expected if you do not use annotations or are using markdown.`
       );
       return [];
     }
 
-    //parse as JSON by removing the old wrapping js syntax. comments and the trailing semi-colon
-    oldAnnotations = oldAnnotations.replace('var comments = ', '');
-    oldAnnotations = oldAnnotations.replace('};', '}');
-
     try {
-      const oldAnnotationsJSON = JSON.parse(oldAnnotations);
-      return oldAnnotationsJSON.comments;
+      const annotationsJSON = JSON.parse(annotations);
+      return annotationsJSON.comments;
     } catch (ex) {
-      logger.error(
-        `There was an error parsing JSON for ${
-          paths.source.annotations
-        }annotations.js`
-      );
+      logger.error(`There was an error parsing JSON for ${jsonPath}`);
       return [];
     }
   }
@@ -108,7 +114,7 @@ const annotations_exporter = function(pl) {
    * @returns array of annotations
    */
   function gatherAnnotations() {
-    const annotationsJS = parseAnnotationsJS();
+    const annotationsJS = parseAnnotationsJSON();
     const annotationsMD = parseAnnotationsMD();
     return _.unionBy(annotationsJS, annotationsMD, 'el');
   }
@@ -117,8 +123,8 @@ const annotations_exporter = function(pl) {
     gather: function() {
       return gatherAnnotations();
     },
-    gatherJS: function() {
-      return parseAnnotationsJS();
+    gatherJSON: function() {
+      return parseAnnotationsJSON();
     },
     gatherMD: function() {
       return parseAnnotationsMD();
@@ -126,4 +132,4 @@ const annotations_exporter = function(pl) {
   };
 };
 
-module.exports = annotations_exporter;
+module.exports = annotationExporter;

--- a/packages/core/src/lib/exportData.js
+++ b/packages/core/src/lib/exportData.js
@@ -4,7 +4,7 @@ const eol = require('os').EOL;
 const path = require('path');
 const _ = require('lodash');
 
-const ae = require('./annotation_exporter');
+const ae = require('./annotationExporter');
 
 let fs = require('fs-extra'); //eslint-disable-line prefer-const
 
@@ -13,7 +13,7 @@ let fs = require('fs-extra'); //eslint-disable-line prefer-const
  * @param patternlab - global data store
  */
 module.exports = function(patternlab) {
-  const annotation_exporter = new ae(patternlab);
+  const annotationExporter = new ae(patternlab);
 
   const paths = patternlab.config.paths;
 
@@ -68,7 +68,7 @@ module.exports = function(patternlab) {
     eol;
 
   //annotations
-  const annotationsJSON = annotation_exporter.gather();
+  const annotationsJSON = annotationExporter.gather();
   const annotations =
     'var comments = { "comments" : ' + JSON.stringify(annotationsJSON) + '};';
   _.each(patternlab.uikits, uikit => {

--- a/packages/core/test/annotation_exporter_tests.js
+++ b/packages/core/test/annotation_exporter_tests.js
@@ -20,12 +20,12 @@ function createFakePatternLab(anPath, customProps) {
 }
 
 var patternlab = createFakePatternLab(anPath);
-var ae = require('../src/lib/annotation_exporter')(patternlab);
+var ae = require('../src/lib/annotationExporter')(patternlab);
 
 tap.test('converts old JS annotations into new format', function(test) {
   //arrange
   //act
-  var annotations = ae.gatherJS();
+  var annotations = ae.gatherJSON();
 
   //assert
   test.equals(annotations.length, 2);
@@ -77,7 +77,7 @@ tap.test('merges both annotation methods into one array', function(test) {
 tap.test('when there are 0 annotation files', function(test) {
   var emptyAnPath = './test/files/empty/';
   var patternlab2 = createFakePatternLab(emptyAnPath);
-  var ae2 = require('../src/lib/annotation_exporter')(patternlab2);
+  var ae2 = require('../src/lib/annotationExporter')(patternlab2);
 
   var annotations = ae2.gather();
   test.equals(annotations.length, 0);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #836 

Summary of changes:
Read annotations.json if it exists. 
Else read annotations.js. 

Not sure if being able to read the old file is a necessary convenience. If not, that part of the code (the else statement) can easily be removed. 