### PR TITLE
Fix Code Panel Toggle Broken on Master (Twig-specific Fix)

### DIFF
--- a/packages/core/src/lib/buildFooter.js
+++ b/packages/core/src/lib/buildFooter.js
@@ -16,11 +16,9 @@ let render = require('./render'); //eslint-disable-line prefer-const
 module.exports = function(patternlab, patternPartial, uikit) {
   //first render the general footer
   return render(
-    Pattern.createEmpty(
-      uikit.footer.path
-        ? { relPath: uikit.footer.path }
-        : { extendedTemplate: uikit.footer }
-    ),
+    uikit.footer.path
+      ? Pattern.createEmpty({ relPath: uikit.footer.path })
+      : Pattern.createEmpty({ extendedTemplate: uikit.footer }),
     {
       patternData: JSON.stringify({
         patternPartial: patternPartial,

--- a/packages/core/src/lib/buildFooter.js
+++ b/packages/core/src/lib/buildFooter.js
@@ -15,12 +15,19 @@ let render = require('./render'); //eslint-disable-line prefer-const
  */
 module.exports = function(patternlab, patternPartial, uikit) {
   //first render the general footer
-  return render(Pattern.createEmpty({ extendedTemplate: uikit.footer }), {
-    patternData: JSON.stringify({
-      patternPartial: patternPartial,
-    }),
-    cacheBuster: patternlab.cacheBuster,
-  })
+  return render(
+    Pattern.createEmpty(
+      uikit.footer.path
+        ? { relPath: uikit.footer.path }
+        : { extendedTemplate: uikit.footer }
+    ),
+    {
+      patternData: JSON.stringify({
+        patternPartial: patternPartial,
+      }),
+      cacheBuster: patternlab.cacheBuster,
+    }
+  )
     .then(footerPartial => {
       let allFooterData;
       try {

--- a/packages/core/src/lib/buildPatterns.js
+++ b/packages/core/src/lib/buildPatterns.js
@@ -100,12 +100,29 @@ module.exports = (deletePatternDir, patternlab, additionalData) => {
                 //cascade any patternStates
                 lineage_hunter.cascade_pattern_states(patternlab);
 
+                let plHeader = Pattern.createEmpty({
+                  extendedTemplate: patternlab.header,
+                });
+
+                // because patternlab.header doesn't yet exist, we need to check the first uikit condfig specified to see if a template path is defined there, otherwise use the original default logic.
+                if (
+                  patternlab.header === undefined &&
+                  patternlab.uikits[Object.keys(patternlab.uikits)[0]]
+                    .header !== undefined &&
+                  patternlab.uikits[Object.keys(patternlab.uikits)[0]].header
+                    .path !== undefined
+                ) {
+                  plHeader = Pattern.createEmpty({
+                    relPath:
+                      patternlab.uikits[Object.keys(patternlab.uikits)[0]]
+                        .header.path,
+                  });
+                }
+
                 //set the pattern-specific header by compiling the general-header with data, and then adding it to the meta header
                 return render(
-                  Pattern.createEmpty({
-                    // todo should this be uikit.header?
-                    extendedTemplate: patternlab.header,
-                  }),
+                  // todo should this be uikit.header?
+                  plHeader,
                   {
                     cacheBuster: patternlab.cacheBuster,
                   }

--- a/packages/core/src/lib/compose.js
+++ b/packages/core/src/lib/compose.js
@@ -68,13 +68,9 @@ module.exports = function(pattern, patternlab) {
         headPromise = render(patternlab.userHead, allData);
       } else {
         headPromise = render(
-          Pattern.createEmpty(
-            uikit.header.path
-              ? {
-                  relPath: uikit.header.path,
-                }
-              : { extendedTemplate: uikit.header }
-          ),
+          uikit.header.path
+            ? Pattern.createEmpty({ relPath: uikit.header.path })
+            : Pattern.createEmpty({ extendedTemplate: uikit.header }),
           allData
         );
       }
@@ -137,13 +133,9 @@ module.exports = function(pattern, patternlab) {
 
       //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
       const footerPartialPromise = render(
-        Pattern.createEmpty(
-          uikit.footer.path
-            ? {
-                relPath: uikit.footer.path,
-              }
-            : { extendedTemplate: uikit.footer }
-        ),
+        uikit.footer.path
+          ? Pattern.createEmpty({ relPath: uikit.footer.path })
+          : Pattern.createEmpty({ extendedTemplate: uikit.footer }),
         {
           isPattern: pattern.isPattern,
           patternData: pattern.patternData,

--- a/packages/core/src/lib/compose.js
+++ b/packages/core/src/lib/compose.js
@@ -68,7 +68,13 @@ module.exports = function(pattern, patternlab) {
         headPromise = render(patternlab.userHead, allData);
       } else {
         headPromise = render(
-          Pattern.createEmpty({ extendedTemplate: uikit.header }),
+          Pattern.createEmpty(
+            uikit.header.path
+              ? {
+                  relPath: uikit.header.path,
+                }
+              : { extendedTemplate: uikit.header }
+          ),
           allData
         );
       }
@@ -131,7 +137,13 @@ module.exports = function(pattern, patternlab) {
 
       //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
       const footerPartialPromise = render(
-        Pattern.createEmpty({ extendedTemplate: uikit.footer }),
+        Pattern.createEmpty(
+          uikit.footer.path
+            ? {
+                relPath: uikit.footer.path,
+              }
+            : { extendedTemplate: uikit.footer }
+        ),
         {
           isPattern: pattern.isPattern,
           patternData: pattern.patternData,

--- a/packages/core/src/lib/loaduikits.js
+++ b/packages/core/src/lib/loaduikits.js
@@ -68,23 +68,38 @@ module.exports = patternlab => {
         outputDir: configEntry.outputDir,
         excludedPatternStates: configEntry.excludedPatternStates,
         excludedTags: configEntry.excludedTags,
-        header: readModuleFile(
-          kit,
-          paths.source.patternlabFiles['general-header']
-        ),
-        footer: readModuleFile(
-          kit,
-          paths.source.patternlabFiles['general-footer']
-        ),
-        patternSection: readModuleFile(
-          kit,
-          paths.source.patternlabFiles.patternSection
-        ),
-        patternSectionSubType: readModuleFile(
-          kit,
-          paths.source.patternlabFiles.patternSectionSubtype
-        ),
-        viewAll: readModuleFile(kit, paths.source.patternlabFiles.viewall),
+
+        /**
+         * If the uikit asset config isn't a simple string path but an object,
+         * don't automatically inline the file's contents. This also keeps the
+         * door open for more advanced configurations down the road!
+         */
+        header: typeof (
+          paths.source.patternlabFiles['general-footer'] === 'object'
+        )
+          ? paths.source.patternlabFiles['general-header']
+          : readModuleFile(kit, paths.source.patternlabFiles['general-footer']),
+        footer: typeof (
+          paths.source.patternlabFiles['general-footer'] === 'object'
+        )
+          ? paths.source.patternlabFiles['general-footer']
+          : readModuleFile(kit, paths.source.patternlabFiles['general-footer']),
+        patternSection: typeof (
+          paths.source.patternlabFiles.patternSection === 'object'
+        )
+          ? paths.source.patternlabFiles.patternSection
+          : readModuleFile(kit, paths.source.patternlabFiles.patternSection),
+        patternSectionSubType: typeof (
+          paths.source.patternlabFiles.patternSectionSubType === 'object'
+        )
+          ? paths.source.patternlabFiles.patternSectionSubType
+          : readModuleFile(
+              kit,
+              paths.source.patternlabFiles.patternSectionSubType
+            ),
+        viewAll: typeof (paths.source.patternlabFiles.viewall === 'object')
+          ? paths.source.patternlabFiles.viewall
+          : readModuleFile(kit, paths.source.patternlabFiles.viewall),
       }; // [3]
     } catch (ex) {
       logger.error(ex);

--- a/packages/core/src/lib/loaduikits.js
+++ b/packages/core/src/lib/loaduikits.js
@@ -74,32 +74,35 @@ module.exports = patternlab => {
          * don't automatically inline the file's contents. This also keeps the
          * door open for more advanced configurations down the road!
          */
-        header: typeof (
-          paths.source.patternlabFiles['general-footer'] === 'object'
-        )
-          ? paths.source.patternlabFiles['general-header']
-          : readModuleFile(kit, paths.source.patternlabFiles['general-footer']),
-        footer: typeof (
-          paths.source.patternlabFiles['general-footer'] === 'object'
-        )
-          ? paths.source.patternlabFiles['general-footer']
-          : readModuleFile(kit, paths.source.patternlabFiles['general-footer']),
-        patternSection: typeof (
-          paths.source.patternlabFiles.patternSection === 'object'
-        )
-          ? paths.source.patternlabFiles.patternSection
-          : readModuleFile(kit, paths.source.patternlabFiles.patternSection),
-        patternSectionSubType: typeof (
-          paths.source.patternlabFiles.patternSectionSubType === 'object'
-        )
-          ? paths.source.patternlabFiles.patternSectionSubType
-          : readModuleFile(
-              kit,
-              paths.source.patternlabFiles.patternSectionSubType
-            ),
-        viewAll: typeof (paths.source.patternlabFiles.viewall === 'object')
-          ? paths.source.patternlabFiles.viewall
-          : readModuleFile(kit, paths.source.patternlabFiles.viewall),
+        header:
+          typeof paths.source.patternlabFiles['general-header'] === 'object'
+            ? paths.source.patternlabFiles['general-header']
+            : readModuleFile(
+                kit,
+                paths.source.patternlabFiles['general-header']
+              ),
+        footer:
+          typeof paths.source.patternlabFiles['general-footer'] === 'object'
+            ? paths.source.patternlabFiles['general-footer']
+            : readModuleFile(
+                kit,
+                paths.source.patternlabFiles['general-footer']
+              ),
+        patternSection:
+          typeof paths.source.patternlabFiles.patternSection === 'object'
+            ? paths.source.patternlabFiles.patternSection
+            : readModuleFile(kit, paths.source.patternlabFiles.patternSection),
+        patternSectionSubType:
+          typeof paths.source.patternlabFiles.patternSectionSubtype === 'object'
+            ? paths.source.patternlabFiles.patternSectionSubtype
+            : readModuleFile(
+                kit,
+                paths.source.patternlabFiles.patternSectionSubtype
+              ),
+        viewAll:
+          typeof paths.source.patternlabFiles.viewall === 'object'
+            ? paths.source.patternlabFiles.viewall
+            : readModuleFile(kit, paths.source.patternlabFiles.viewall),
       }; // [3]
     } catch (ex) {
       logger.error(ex);

--- a/packages/core/src/lib/ui_builder.js
+++ b/packages/core/src/lib/ui_builder.js
@@ -519,13 +519,9 @@ const ui_builder = function() {
    */
   function buildViewAllHTML(patternlab, patterns, patternPartial, uikit) {
     return render(
-      Pattern.createEmpty(
-        uikit.viewAll.path
-          ? {
-              relPath: uikit.viewAll.path,
-            }
-          : { extendedTemplate: uikit.viewAll }
-      ),
+      uikit.viewAll.path
+        ? Pattern.createEmpty({ relPath: uikit.viewAll.path })
+        : Pattern.createEmpty({ extendedTemplate: uikit.viewAll }),
       {
         //data
         partials: patterns,
@@ -770,15 +766,9 @@ const ui_builder = function() {
       return new Promise(resolve => {
         //set the pattern-specific header by compiling the general-header with data, and then adding it to the meta header
         const headerPromise = render(
-          Pattern.createEmpty(
-            uikit.header.path
-              ? {
-                  relPath: uikit.header.path,
-                }
-              : {
-                  extendedTemplate: uikit.header,
-                }
-          ),
+          uikit.header.path
+            ? Pattern.createEmpty({ relPath: uikit.header.path })
+            : Pattern.createEmpty({ extendedTemplate: uikit.header }),
           {
             cacheBuster: patternlab.cacheBuster,
           }
@@ -796,15 +786,9 @@ const ui_builder = function() {
 
         //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
         const footerPromise = render(
-          Pattern.createEmpty(
-            uikit.footer.path
-              ? {
-                  relPath: uikit.footer.path,
-                }
-              : {
-                  extendedTemplate: uikit.footer,
-                }
-          ),
+          uikit.footer.path
+            ? Pattern.createEmpty({ relPath: uikit.footer.path })
+            : Pattern.createEmpty({ extendedTemplate: uikit.footer }),
           {
             patternData: '{}',
             cacheBuster: patternlab.cacheBuster,
@@ -846,15 +830,13 @@ const ui_builder = function() {
 
                 //build the main styleguide page
                 return render(
-                  Pattern.createEmpty(
-                    uikit.viewAll.path
-                      ? {
-                          relPath: uikit.viewAll.path,
-                        }
-                      : {
-                          extendedTemplate: uikit.viewAll,
-                        }
-                  ),
+                  uikit.viewAll.path
+                    ? Pattern.createEmpty({
+                        relPath: uikit.viewAll.path,
+                      })
+                    : Pattern.createEmpty({
+                        extendedTemplate: uikit.viewAll,
+                      }),
                   {
                     partials: uniquePatterns,
                   },

--- a/packages/core/src/lib/ui_builder.js
+++ b/packages/core/src/lib/ui_builder.js
@@ -519,7 +519,13 @@ const ui_builder = function() {
    */
   function buildViewAllHTML(patternlab, patterns, patternPartial, uikit) {
     return render(
-      Pattern.createEmpty({ extendedTemplate: uikit.viewAll }),
+      Pattern.createEmpty(
+        uikit.viewAll.path
+          ? {
+              relPath: uikit.viewAll.path,
+            }
+          : { extendedTemplate: uikit.viewAll }
+      ),
       {
         //data
         partials: patterns,
@@ -764,7 +770,15 @@ const ui_builder = function() {
       return new Promise(resolve => {
         //set the pattern-specific header by compiling the general-header with data, and then adding it to the meta header
         const headerPromise = render(
-          Pattern.createEmpty({ extendedTemplate: uikit.header }),
+          Pattern.createEmpty(
+            uikit.header.path
+              ? {
+                  relPath: uikit.header.path,
+                }
+              : {
+                  extendedTemplate: uikit.header,
+                }
+          ),
           {
             cacheBuster: patternlab.cacheBuster,
           }
@@ -782,7 +796,15 @@ const ui_builder = function() {
 
         //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
         const footerPromise = render(
-          Pattern.createEmpty({ extendedTemplate: uikit.footer }),
+          Pattern.createEmpty(
+            uikit.footer.path
+              ? {
+                  relPath: uikit.footer.path,
+                }
+              : {
+                  extendedTemplate: uikit.footer,
+                }
+          ),
           {
             patternData: '{}',
             cacheBuster: patternlab.cacheBuster,
@@ -824,9 +846,15 @@ const ui_builder = function() {
 
                 //build the main styleguide page
                 return render(
-                  Pattern.createEmpty({
-                    extendedTemplate: uikit.viewAll,
-                  }),
+                  Pattern.createEmpty(
+                    uikit.viewAll.path
+                      ? {
+                          relPath: uikit.viewAll.path,
+                        }
+                      : {
+                          extendedTemplate: uikit.viewAll,
+                        }
+                  ),
                   {
                     partials: uniquePatterns,
                   },

--- a/packages/edition-twig/package-lock.json
+++ b/packages/edition-twig/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "@pattern-lab/edition-twig",
+	"version": "3.0.0-alpha.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@pattern-lab/starterkit-twig-demo": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@pattern-lab/starterkit-twig-demo/-/starterkit-twig-demo-4.0.0.tgz",
+			"integrity": "sha512-GDSKRgDT4BugTcEDRv3oH0+Lc9sUHWbUS6L1GPsLHr5PsJ/AdGdQOqTfrePZJMq2d/4xxGxQLAH2Ua6wagg0eg=="
+		}
+	}
+}

--- a/packages/edition-twig/package.json
+++ b/packages/edition-twig/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@pattern-lab/cli": "^0.0.1-alpha.19",
     "@pattern-lab/core": "^3.0.0-alpha.13",
-    "@pattern-lab/engine-mustache": "^2.0.0-alpha.6",
     "@pattern-lab/engine-twig-php": "^0.1.0",
-    "@pattern-lab/uikit-workshop": "^1.0.0-alpha.5"
+    "@pattern-lab/uikit-workshop": "^1.0.0-alpha.5",
+    "@pattern-lab/starterkit-twig-demo": "^4.0.0"
   },
   "engines": {
     "node": ">=6.0"

--- a/packages/edition-twig/patternlab-config.json
+++ b/packages/edition-twig/patternlab-config.json
@@ -3,6 +3,13 @@
     "twig": {
       "namespaces": [
         {
+          "id": "uikit",
+          "recursive": true,
+          "paths": [
+            "../uikit-workshop/views-twig/"
+          ]
+        },
+        {
           "id": "atoms",
           "recursive": true,
           "paths": [
@@ -101,11 +108,26 @@
       "annotations": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_annotations/",
       "styleguide": "dist/",
       "patternlabFiles": {
-        "general-header": "views/partials/general-header.mustache",
-        "general-footer": "views/partials/general-footer.mustache",
-        "patternSection": "views/partials/patternSection.mustache",
-        "patternSectionSubtype": "views/partials/patternSectionSubtype.mustache",
-        "viewall": "views/viewall.mustache"
+        "general-header": {
+          "inline": false,
+          "path": "@uikit/general-header.twig"
+        },
+        "general-footer": {
+          "inline": false,
+          "path": "@uikit/general-footer.twig"
+        },
+        "patternSection": {
+          "inline": false,
+          "path": "@uikit/patternSection.twig"
+        },
+        "patternSectionSubtype": {
+          "inline": false,
+          "path": "@uikit/patternSectionSubtype.twig"
+        },
+        "viewall": {
+          "inline": false,
+          "path": "@uikit/viewall.twig"
+        }
       },
       "js": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/js",
       "images": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/images",

--- a/packages/edition-twig/patternlab-config.json
+++ b/packages/edition-twig/patternlab-config.json
@@ -109,23 +109,18 @@
       "styleguide": "dist/",
       "patternlabFiles": {
         "general-header": {
-          "inline": false,
           "path": "@uikit/general-header.twig"
         },
         "general-footer": {
-          "inline": false,
           "path": "@uikit/general-footer.twig"
         },
         "patternSection": {
-          "inline": false,
           "path": "@uikit/patternSection.twig"
         },
         "patternSectionSubtype": {
-          "inline": false,
           "path": "@uikit/patternSectionSubtype.twig"
         },
         "viewall": {
-          "inline": false,
           "path": "@uikit/viewall.twig"
         }
       },

--- a/packages/edition-twig/patternlab-config.json
+++ b/packages/edition-twig/patternlab-config.json
@@ -6,42 +6,42 @@
           "id": "atoms",
           "recursive": true,
           "paths": [
-            "source/_patterns/00-atoms"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/00-atoms"
           ]
         },
         {
           "id": "molecules",
           "recursive": true,
           "paths": [
-            "source/_patterns/01-molecules"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/01-molecules"
           ]
         },
         {
           "id": "organisms",
           "recursive": true,
           "paths": [
-            "source/_patterns/02-organisms"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/02-organisms"
           ]
         },
         {
           "id": "templates",
           "recursive": true,
           "paths": [
-            "source/_patterns/03-templates"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/03-templates"
           ]
         },
         {
           "id": "pages",
           "recursive": true,
           "paths": [
-            "source/_patterns/04-pages"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/04-pages"
           ]
         },
         {
           "id": "macros",
           "recursive": true,
           "paths": [
-            "source/_macros"
+            "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_macros"
           ]
         }
       ],
@@ -94,11 +94,11 @@
   },
   "paths": {
     "source": {
-      "root": "./source/",
-      "patterns": "./source/_patterns/",
-      "data": "./source/_data/",
-      "meta": "./source/_meta/",
-      "annotations": "./source/_annotations/",
+      "root": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/",
+      "patterns": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_patterns/",
+      "data": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_data/",
+      "meta": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_meta/",
+      "annotations": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/_annotations/",
       "styleguide": "dist/",
       "patternlabFiles": {
         "general-header": "views/partials/general-header.mustache",
@@ -107,10 +107,10 @@
         "patternSectionSubtype": "views/partials/patternSectionSubtype.mustache",
         "viewall": "views/viewall.mustache"
       },
-      "js": "./source/js",
-      "images": "./source/images",
-      "fonts": "./source/fonts",
-      "css": "./source/css"
+      "js": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/js",
+      "images": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/images",
+      "fonts": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/fonts",
+      "css": "./node_modules/@pattern-lab/starterkit-twig-demo/dist/css"
     },
     "public": {
       "root": "public/",

--- a/packages/uikit-workshop/views-twig/README
+++ b/packages/uikit-workshop/views-twig/README
@@ -1,0 +1,1 @@
+There should be no reason to touch these files in day-to-day use.

--- a/packages/uikit-workshop/views-twig/partials/general-footer.twig
+++ b/packages/uikit-workshop/views-twig/partials/general-footer.twig
@@ -1,0 +1,56 @@
+<script type="text/json" id="pl-pattern-data-footer" class="pl-js-pattern-data">
+  {{ patternData | raw }}
+</script>
+
+<script>
+  /*!
+   * scriptLoader - v0.1
+   *
+   * Copyright (c) 2014 Dave Olsen, http://dmolsen.com
+   * Licensed under the MIT license
+   *
+   */
+
+  var scriptLoader = {
+
+    run: function(js,cb,target) {
+      var s  = document.getElementById(target+'-'+cb);
+      for (var i = 0; i < js.length; i++) {
+        var src = (typeof js[i] != 'string') ? js[i].src : js[i];
+        var c   = document.createElement('script');
+        c.src   = '../../'+src+'?'+cb;
+        if (typeof js[i] != 'string') {
+          if (js[i].dep !== undefined) {
+            c.onload = function(dep,cb,target) {
+              return function() {
+                scriptLoader.run(dep,cb,target);
+              }
+            }(js[i].dep,cb,target);
+          }
+        }
+        s.parentNode.insertBefore(c,s);
+      }
+    }
+
+  }
+</script>
+
+<script id="pl-js-polyfill-insert-{{ cacheBuster }}">
+  (function() {
+    if (self != top) {
+      var cb = '{{ cacheBuster}}';
+      var js = [];
+      scriptLoader.run(js,cb,'pl-js-polyfill-insert');
+    }
+  })();
+</script>
+
+<script id="pl-js-insert-{{ cacheBuster }}">
+  (function() {
+    if (self != top) {
+      var cb = '{{ cacheBuster}}';
+      var js = [ { 'src': 'styleguide/bower_components/jwerty.min.js', 'dep': [ 'styleguide/js/patternlab-pattern.min.js' ] } ];
+      scriptLoader.run(js,cb,'pl-js-insert');
+    }
+  })();
+</script>

--- a/packages/uikit-workshop/views-twig/partials/general-header.twig
+++ b/packages/uikit-workshop/views-twig/partials/general-header.twig
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="../../styleguide/css/pattern-lab.css?{{ cacheBuster }}" media="all">

--- a/packages/uikit-workshop/views-twig/partials/patternSection.twig
+++ b/packages/uikit-workshop/views-twig/partials/patternSection.twig
@@ -1,0 +1,34 @@
+<div id="{{ partial.patternPartial }}" class="pl-c-pattern">
+    
+  <div class="pl-c-pattern__header">
+    <h3 class="pl-c-pattern__title">
+      <a href="../../patterns/{{ partial.patternLink }}" class="pl-c-pattern__title-link patternLink" data-patternpartial="{{ partial.patternPartial }}" title="Link to Pattern">
+        {{ partial.patternName }}
+        {% if partial.patternState %}
+          <span class="pl-c-pattern-state pl-c-pattern-state--{{ partial.patternState }}" title="{{ partial.patternState }}">{{ partial.patternState }}</span>
+        {% endif %}
+      </a>
+    </h3>
+    
+    <!-- @todo: why doesn't PL node have breadcrumbs?? -- keeping in the Twig version -->
+    <div class="sg-pattern-breadcrumb pl-c-pattern-breadcrumb">
+      {{ partial.patternBreadcrumb }}
+    </div>
+
+
+    <button class="pl-c-pattern__extra-toggle pl-js-pattern-extra-toggle" id="pl-pattern-extra-toggle-{{partial.patternPartial}}" data-patternpartial="{{ partial.patternPartial }}" title="View Pattern Info">
+      <span class="pl-c-pattern__toggle-icon">&#9660;</span>
+    </button><!--end pl-c-pattern__extra-toggle-->
+  </div><!--end pl-c-pattern__header-->
+
+  <div class="pl-c-pattern__extra pl-js-pattern-extra" id="pl-pattern-extra-{{ partial.patternPartial }}"></div><!--end pl-c-pattern__extra-->
+
+  <div class="pl-js-pattern-example">
+    {{ partial.patternPartialCode | raw }}
+  </div><!--end pl-js-pattern-example-->
+
+  <script type="text/json" id="pl-pattern-data-{{partial.patternPartial}}" class="pl-js-pattern-data">
+    {{ partial.patternData | raw }}
+  </script>
+
+</div><!--end pl-c-pattern-->

--- a/packages/uikit-workshop/views-twig/partials/patternSection.twig
+++ b/packages/uikit-workshop/views-twig/partials/patternSection.twig
@@ -1,5 +1,5 @@
 <div id="{{ partial.patternPartial }}" class="pl-c-pattern">
-    
+
   <div class="pl-c-pattern__header">
     <h3 class="pl-c-pattern__title">
       <a href="../../patterns/{{ partial.patternLink }}" class="pl-c-pattern__title-link patternLink" data-patternpartial="{{ partial.patternPartial }}" title="Link to Pattern">
@@ -9,7 +9,7 @@
         {% endif %}
       </a>
     </h3>
-    
+
     <!-- @todo: why doesn't PL node have breadcrumbs?? -- keeping in the Twig version -->
     <div class="sg-pattern-breadcrumb pl-c-pattern-breadcrumb">
       {{ partial.patternBreadcrumb }}
@@ -28,7 +28,24 @@
   </div><!--end pl-js-pattern-example-->
 
   <script type="text/json" id="pl-pattern-data-{{partial.patternPartial}}" class="pl-js-pattern-data">
-    {{ partial.patternData | raw }}
+    {# original data structure expected by uikit JS / available to patterns being rendered #}
+    {% if partial.patternData %}
+      {{ partial.patternData | raw }}
+
+    {# ^ original data structure manually recreated based on the individual fields currently available. @todo: revisit when uikit JS refactored #}
+    {% else %}
+      {% set patternData = partial | merge({
+        "lineage": partial.patternData.lineage ? partial.patternData.lineage : partial.lineage | default([]),
+        "lineageR": partial.patternData.lineageR ? partial.patternData.lineageR : partial.lineageR | default([]),
+        "patternBreadcrumb": partial.patternData.patternBreadcrumb ? partial.patternData.patternBreadcrumb : partial.patternBreadcrumb | default(""),
+        "patternDesc": partial.patternData.patternDesc ? partial.patternData.patternDesc : partial.patternDesc | default(""),
+        "patternExtension": partial.patternData.patternExtension ? partial.patternData.patternExtension : partial.fileExtension | replace({".": ""}),
+        "patternName": partial.patternData.patternName ? partial.patternData.patternName : partial.patternName,
+        "patternPartial": partial.patternData.patternPartial ? partial.patternData.patternPartial : partial.patternPartial,
+        "patternState": partial.patternData.patternState ? partial.patternData.patternState : partial.patternState,
+      }) %}
+      {{ patternData | json_encode() }}
+    {% endif %}
   </script>
 
 </div><!--end pl-c-pattern-->

--- a/packages/uikit-workshop/views-twig/partials/patternSectionSubtype.twig
+++ b/packages/uikit-workshop/views-twig/partials/patternSectionSubtype.twig
@@ -1,0 +1,11 @@
+<div id="{{ partial.patternPartial }}" class="pl-c-category">
+
+  <h2 class="pl-c-category__title">
+    <a href="../../patterns/{{ partial.patternLink }}" class="pl-c-category__title-link patternLink" data-patternpartial="{{ partial.patternPartial }}">{{ partial.patternName }}</a>
+  </h2><!--end pl-c-category__title-->
+
+  <div class="pl-c-category__description pl-c-text-passage">
+    {{ partial.patternDesc | raw }}
+  </div><!--end pl-c-category__description-->
+
+</div><!--end pl-c-category-->

--- a/packages/uikit-workshop/views-twig/viewall.twig
+++ b/packages/uikit-workshop/views-twig/viewall.twig
@@ -1,0 +1,13 @@
+<!-- View All Patterns in a Pattern Sub-Type -->
+<div class="pl-c-main">
+  <!-- Index of Patterns -->
+  <div class="pl-c-pattern-index">
+    {% for partial in partials %}
+      {% if partial.patternSectionSubtype %}
+        {% include "@uikit/patternSectionSubtype.twig" %}
+      {% else %}
+        {% include "@uikit/patternSection.twig" %}
+      {% endif %}
+    {% endfor %}
+  </div><!--end pl-c-pattern-index-->
+</div><!--end pl-c-main-->


### PR DESCRIPTION
Specifically, see changes from lines 30 to 49: https://github.com/pattern-lab/patternlab-node/compare/feature/engine-twig-php...sghoweri:feature/engine-twig-php--fix-code-panel-in-twig?expand=1#diff-a3e7ad2ea7763bc4319b1779d5bfbc8eR30 -- unfortunately this is based off of my other open PR #902 since this specifically updates on Twig template to fix the data structure expected by the current UIkit JavaScript.

In any case, this is a partial Twig-specific fix for the collapsible code panels being broken on master, most likely due to internal data structure changes implemented at some point. 

These updates fix the issue reported in #761 however are unfortunately Twig specific for now until the underlying changes are identified and internally exported data structures are updated accordingly.
