### PR TITLE
Partial Fix for Code Panel Toggle JS Errors on Master

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 packages/core/scripts/api.handlebars
 packages/core/scripts/events.handlebars
 packages/core/test/files/annotations.js
+**/uikit-workshop/src/js/**/*

--- a/packages/uikit-workshop/src/js/modal-styleguide.js
+++ b/packages/uikit-workshop/src/js/modal-styleguide.js
@@ -121,7 +121,7 @@ var modalStyleguide = {
      * getting thrown when certain script tags aren't rendered with partial.patternData content.
      */
     if (/\S/.test(el.innerHTML)) {
-      const patternData = JSON.parse(el.innerHTML);
+      var patternData = JSON.parse(el.innerHTML);
       if (patternData.patternName !== undefined) {
         patternMarkupEl = document.querySelector(
           '#' + patternData.patternPartial + ' > .pl-js-pattern-example'

--- a/packages/uikit-workshop/src/js/modal-styleguide.js
+++ b/packages/uikit-workshop/src/js/modal-styleguide.js
@@ -116,16 +116,29 @@ var modalStyleguide = {
    * @param  {Boolean}      if the text in the dropdown should be switched
    */
   collectAndSend: function(el, iframePassback, switchText) {
-    var patternData = JSON.parse(el.innerHTML);
-    if (patternData.patternName !== undefined) {
-      patternMarkupEl = document.querySelector(
-        '#' + patternData.patternPartial + ' > .pl-js-pattern-example'
-      );
-      patternData.patternMarkup =
-        patternMarkupEl !== null
-          ? patternMarkupEl.innerHTML
-          : document.querySelector('body').innerHTML;
-      modalStyleguide.patternQueryInfo(patternData, iframePassback, switchText);
+    /**
+     * Verify <script> tag has JSON data available (not just whitespace) - helps prevents JS errors from
+     * getting thrown when certain script tags aren't rendered with partial.patternData content.
+     */
+    if (/\S/.test(el.innerHTML)) {
+      const patternData = JSON.parse(el.innerHTML);
+      if (patternData.patternName !== undefined) {
+        patternMarkupEl = document.querySelector(
+          '#' + patternData.patternPartial + ' > .pl-js-pattern-example'
+        );
+        patternData.patternMarkup =
+          patternMarkupEl !== null
+            ? patternMarkupEl.innerHTML
+            : document.querySelector('body').innerHTML;
+        modalStyleguide.patternQueryInfo(
+          patternData,
+          iframePassback,
+          switchText
+        );
+      }
+    } else {
+      // @todo: how are we handling conditional logging for debugging based on the dev environment?
+      // console.log('This <script> tag\'s JSON is empty for some reason...');
     }
   },
 


### PR DESCRIPTION
Checks to make sure the code panel-related <script> tag contains data before attempting to parse expected JSON. 

Partial fix to #761 as this should at least help prevent the current batch of JS errors from getting thrown till the larger data structure changes that caused this issue are identified and a fix rolled up. 

Related to #905 as Twig allows us to massage the data available at the template level to work around whatever data changes happened to cause this bug in the first place.