### PR TITLE
Add Example of Toggling Twig Debug Mode in New Twig PHP Engine

### DIFF
--- a/packages/edition-twig/alter-twig.php
+++ b/packages/edition-twig/alter-twig.php
@@ -27,4 +27,8 @@ function addCustomExtension(\Twig_Environment &$env, $config) {
 
 //  `{{ foo }}` => `bar`
 //  $env->addGlobal('foo', 'bar');
+
+  // example of enabling the Twig debug mode extension (ex. {{ dump(my_variable) }} to check out the template's available data) -- comment out to disable
+  $env->addExtension(new \Twig_Extension_Debug());
+
 }

--- a/packages/edition-twig/alter-twig.php
+++ b/packages/edition-twig/alter-twig.php
@@ -29,6 +29,6 @@ function addCustomExtension(\Twig_Environment &$env, $config) {
 //  $env->addGlobal('foo', 'bar');
 
   // example of enabling the Twig debug mode extension (ex. {{ dump(my_variable) }} to check out the template's available data) -- comment out to disable
-  $env->addExtension(new \Twig_Extension_Debug());
+  // $env->addExtension(new \Twig_Extension_Debug());
 
 }


### PR DESCRIPTION
@EvanLovely just a tiny suggestion to your existing Twig PHP Engine PR #897 -- this just adds an example of how to enable Twig Debug mode (ie. `{{ dump(my_var) }}` ) for folks that aren't familiar with how exactly you switch that on or off with the new setup 😉