### PR TITLE
Nunjucks loader to resolve Pattern Lab include paths

### DIFF
--- a/packages/engine-nunjucks/README.md
+++ b/packages/engine-nunjucks/README.md
@@ -17,10 +17,10 @@ Level of Support is more or less full. Partial calls and lineage hunting are sup
 
 ## Extending the Nunjucks instance
 
-To add custom filters or make customizations to the nunjucks instance, create a file named `patternlab-nunjucks-config.js` in the root of your Pattern Lab project. `patternlab-nunjucks-config.js` should export a function that takes two parameters. The first parameter is the nunjucks instance; the second is the nunjucks instance's environment.
+To add custom filters or make customizations to the nunjucks instance, create a file named `patternlab-nunjucks-config.js` in the root of your Pattern Lab project. `patternlab-nunjucks-config.js` should export a function with the Nunjucks environment as parameter.
 
 ```
-module.exports = function (nunjucks, env) {
+module.exports = function (env) {
   [YOUR CUSTOM CODE HERE]
 };
 ```
@@ -30,7 +30,7 @@ Example: `patternlab-nunjucks-config.js` file that uses lodash and adds three cu
 var _shuffle = require('lodash/shuffle'),
   _take = require('lodash/take');
 
-exports = module.exports = function (nunjucks, env) {
+exports = module.exports = function (env) {
   env.addFilter('shorten', function (str, count) {
     return str.slice(0, count || 5);
   });

--- a/packages/engine-nunjucks/lib/engine_nunjucks.js
+++ b/packages/engine-nunjucks/lib/engine_nunjucks.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var fs = require('fs-extra'),
+let fs = require('fs-extra'),
   path = require('path'),
   plPath = process.cwd(),
   plConfig = require(path.join(plPath, 'patternlab-config.json')),
@@ -32,11 +32,11 @@ var fs = require('fs-extra'),
 // LOAD ANY USER NUNJUCKS CONFIGURATIONS
 ////////////////////////////
 try {
-  var nunjucksConfig = require(path.join(
+  let nunjucksConfig = require(path.join(
     plPath,
     'patternlab-nunjucks-config.js'
   ));
-  if (typeof nunjucksConfig == 'function') {
+  if (typeof nunjucksConfig === 'function') {
     nunjucksConfig(nunjucks, env);
   }
 } catch (err) {}
@@ -53,7 +53,7 @@ if (!String.prototype.replaceAll) {
         str1.replace(/([\/\,\!\\\^\$\{\}\[\]\(\)\.\*\+\?\|\<\>\-\&])/g, '\\$&'),
         ignore ? 'gi' : 'g'
       ),
-      typeof str2 == 'string' ? str2.replace(/\$/g, '$$$$') : str2
+      typeof str2 === 'string' ? str2.replace(/\$/g, '$$$$') : str2
     );
   };
 }
@@ -61,7 +61,7 @@ if (!String.prototype.replaceAll) {
 ////////////////////////////
 // NUNJUCKS ENGINE
 ////////////////////////////
-var engine_nunjucks = {
+let engine_nunjucks = {
   engine: nunjucks,
   engineName: 'nunjucks',
   engineFileExtension: '.njk',
@@ -79,7 +79,7 @@ var engine_nunjucks = {
     try {
       // replace pattern names with their full path so Nunjucks can find them.
       pattern.extendedTemplate = this.replacePartials(pattern);
-      var result = nunjucks.renderString(pattern.extendedTemplate, data);
+      let result = nunjucks.renderString(pattern.extendedTemplate, data);
       return Promise.resolve(result);
     } catch (err) {
       console.error('Failed to render pattern: ' + pattern.name);
@@ -88,14 +88,14 @@ var engine_nunjucks = {
 
   // find and return any Nunjucks style includes/imports/extends within pattern
   findPartials: function findPartials(pattern) {
-    var matches = pattern.template.match(this.findPartialsRE);
+    let matches = pattern.template.match(this.findPartialsRE);
     return matches;
   },
 
   // given a pattern, and a partial string, tease out the "pattern key" and return it.
   findPartial: function(partialString) {
     try {
-      var partial = partialString.match(this.findPartialKeyRE)[1];
+      let partial = partialString.match(this.findPartialKeyRE)[1];
       partial = partial.replace(/["']/g, '');
       return partial;
     } catch (err) {
@@ -118,13 +118,13 @@ var engine_nunjucks = {
 
   replacePartials: function(pattern) {
     try {
-      var partials = this.findPartials(pattern);
+      let partials = this.findPartials(pattern);
       if (partials !== null) {
-        for (var i = 0; i < partials.length; i++) {
+        for (let i = 0; i < partials.length; i++) {
           // e.g. {% include "atoms-parent" %}
-          var partialName = this.findPartial(partials[i]); // e.g. atoms-parent
-          var partialFullPath = partialRegistry[partialName]; // e.g. 00-atoms/01-parent.njk
-          var newPartial = partials[i].replaceAll(
+          let partialName = this.findPartial(partials[i]); // e.g. atoms-parent
+          let partialFullPath = partialRegistry[partialName]; // e.g. 00-atoms/01-parent.njk
+          let newPartial = partials[i].replaceAll(
             partialName,
             partialFullPath,
             true
@@ -147,7 +147,7 @@ var engine_nunjucks = {
 
   // still requires the mustache syntax because of the way PL handles lists
   findListItems: function(pattern) {
-    var matches = pattern.template.match(this.findListItemsRE);
+    let matches = pattern.template.match(this.findListItemsRE);
     return matches;
   },
 

--- a/packages/engine-nunjucks/lib/engine_nunjucks.js
+++ b/packages/engine-nunjucks/lib/engine_nunjucks.js
@@ -76,6 +76,7 @@ const engine_nunjucks = {
       return Promise.resolve(result);
     } catch (err) {
       console.error('Failed to render pattern: ' + pattern.name);
+      console.error(err);
     }
   },
 

--- a/packages/engine-nunjucks/lib/engine_nunjucks.js
+++ b/packages/engine-nunjucks/lib/engine_nunjucks.js
@@ -51,7 +51,7 @@ try {
     'patternlab-nunjucks-config.js'
   ));
   if (typeof nunjucksConfig === 'function') {
-    nunjucksConfig(nunjucks, env);
+    nunjucksConfig(env);
   }
 } catch (err) {}
 

--- a/packages/engine-nunjucks/package.json
+++ b/packages/engine-nunjucks/package.json
@@ -26,7 +26,7 @@
   "main": "lib/engine_nunjucks.js",
   "name": "@pattern-lab/engine-nunjucks",
   "scripts": {},
-  "version": "0.2.0-alpha.5",
+  "version": "0.1.4-alpha.4",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/engine-nunjucks/package.json
+++ b/packages/engine-nunjucks/package.json
@@ -7,8 +7,8 @@
   "deprecated": false,
   "description": "The nunjucks PatternEngine for Pattern Lab / Node",
   "dependencies": {
-    "fs-extra": "5.0.0",
-    "nunjucks": "3.0.1"
+    "fs-extra": "7.0.0",
+    "nunjucks": "3.1.3"
   },
   "engines": {
     "node": ">=4.0"

--- a/packages/engine-nunjucks/package.json
+++ b/packages/engine-nunjucks/package.json
@@ -26,7 +26,7 @@
   "main": "lib/engine_nunjucks.js",
   "name": "@pattern-lab/engine-nunjucks",
   "scripts": {},
-  "version": "0.1.4-alpha.4",
+  "version": "0.2.0-alpha.5",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Creates a custom Nunjucks loader to resolve Pattern Lab paths. 

This replaces the hacky search and replace method that exists currently. Also fixes an issue with including patterns that contain includes.