### PR TITLE
[uikit-workshop] Remove copy-dist flag and logic from UIKit-Workshop

### DIFF
--- a/packages/uikit-workshop/.github/CONTRIBUTING.md
+++ b/packages/uikit-workshop/.github/CONTRIBUTING.md
@@ -19,11 +19,11 @@ The best way to make changes to this repo and test them is through your existing
 
 To make changes **always edit files in `src/`**. To make sure that these changes are reflected in the front-end and `dist/` folder run the following:
 
-    gulp --copy-dist=../../../public
+    npm run build
 
 To watch for changes you can use:
 
-    gulp --watch --copy-dist=../../../public
+    npm run watch
 
 At this point changes to the static assets should compile to the correct locations in the project as well as `dist/`.
 

--- a/packages/uikit-workshop/gulpfile.js
+++ b/packages/uikit-workshop/gulpfile.js
@@ -11,21 +11,11 @@ const { buildCriticalCSS } = require('./penthouse');
 // @todo: uncomment once cache-busting strategy in place.
 // const workboxBuild = require('workbox-build');
 
-
 /* load the plugins */
 const gulpLoadPlugins = require('gulp-load-plugins');
 const plugins = gulpLoadPlugins({ scope: ['devDependencies'] });
 plugins.del = require('del');
 plugins.mainBowerFiles = require('main-bower-files');
-
-/* copy the dist folder into the designated public folder */
-function copyPublic(suffix) {
-  if (args['copy-dist'] !== undefined) {
-    return gulp.dest(args['copy-dist'] + '/' + suffix);
-  } else {
-    return plugins.util.noop();
-  }
-}
 
 /* clean tasks */
 gulp.task('clean', function(cb) {
@@ -38,8 +28,7 @@ gulp.task('build:bower', ['clean'], function() {
     .src(plugins.mainBowerFiles())
     .pipe(plugins.rename({ suffix: '.min' }))
     .pipe(plugins.uglify())
-    .pipe(gulp.dest('dist/styleguide/bower_components'))
-    .pipe(copyPublic('styleguide/bower_components'));
+    .pipe(gulp.dest('dist/styleguide/bower_components'));
 });
 
 gulp.task('build:css', ['clean'], function() {
@@ -79,8 +68,7 @@ gulp.task('build:css', ['clean'], function() {
         inline: ['remote'],
       })
     )
-    .pipe(gulp.dest('dist/styleguide/css'))
-    .pipe(copyPublic('styleguide/css'));
+    .pipe(gulp.dest('dist/styleguide/css'));
 });
 
 gulp.task(
@@ -99,8 +87,7 @@ gulp.task('copy:js', ['clean'], function() {
       'node_modules/whendefined/dist/whendefined.min.js',
       'node_modules/fg-loadjs/loadJS.js',
     ])
-    .pipe(gulp.dest('dist/styleguide/js'))
-    .pipe(copyPublic(''));
+    .pipe(gulp.dest('dist/styleguide/js'));
 });
 
 gulp.task(
@@ -110,8 +97,7 @@ gulp.task(
     return gulp
       .src('src/html/index.html')
       .pipe(plugins.fileInclude({ prefix: '@@', basepath: '@file' }))
-      .pipe(gulp.dest('dist'))
-      .pipe(copyPublic(''));
+      .pipe(gulp.dest('dist'));
   }
 );
 
@@ -124,8 +110,7 @@ gulp.task('build:html', ['clean', 'criticalcss', 'prebuild:html'], function() {
         compress: true,
       })
     )
-    .pipe(gulp.dest('dist'))
-    .pipe(copyPublic(''));
+    .pipe(gulp.dest('dist'));
 });
 
 gulp.task('build:images', ['clean'], function() {
@@ -138,8 +123,7 @@ gulp.task('build:images', ['clean'], function() {
         use: [plugins.pngcrush()],
       })
     )
-    .pipe(gulp.dest('dist/styleguide/images'))
-    .pipe(copyPublic('styleguide/images'));
+    .pipe(gulp.dest('dist/styleguide/images'));
 });
 
 gulp.task('build:js-viewer', ['clean'], function() {
@@ -157,8 +141,7 @@ gulp.task('build:js-viewer', ['clean'], function() {
     .pipe(gulp.dest('dist/styleguide/js'))
     .pipe(plugins.rename({ suffix: '.min' }))
     .pipe(plugins.uglify())
-    .pipe(gulp.dest('dist/styleguide/js'))
-    .pipe(copyPublic('styleguide/js'));
+    .pipe(gulp.dest('dist/styleguide/js'));
 });
 
 gulp.task('build:js-pattern', ['clean', 'build:js-viewer'], function() {
@@ -182,8 +165,7 @@ gulp.task('build:js-pattern', ['clean', 'build:js-viewer'], function() {
     .pipe(gulp.dest('dist/styleguide/js'))
     .pipe(plugins.rename({ suffix: '.min' }))
     .pipe(plugins.uglify())
-    .pipe(gulp.dest('dist/styleguide/js'))
-    .pipe(copyPublic('styleguide/js'));
+    .pipe(gulp.dest('dist/styleguide/js'));
 });
 
 // @todo: re-enable once cache busting strategy in place


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #913 

Summary of changes: 
- Updated uikit-workshop's CONTRIBUTING.md to mention npm scripts rather then gulp
- Removed `copyPublic` function and calls from uikit-workshop's gulpfile