### PR TITLE
fix: Prettier should only format .js files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,6 @@ packages/core/scripts/api.handlebars
 packages/core/scripts/events.handlebars
 packages/core/test/files/annotations.js
 **/uikit-workshop/src/js/**/*
+*.json
+*.md
+*.scss

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bootstrap": "npx lerna bootstrap",
     "precommit": "pretty-quick --staged",
-    "prettier": "prettier --config .prettierrc --write ./**/*.js",
+    "prettier": "prettier --config .prettierrc --write ./**/*.js --ignore-path .prettierignore",
     "test": "lerna run test",
     "clean": "git clean -dfx"
   },


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #910 

Summary of changes: Updated .prettierignore and anded ignore path to npm prettier script
