### PR TITLE
fix(patterns): find all patterns inlcuding pseudo patterns

### DIFF
--- a/packages/core/src/lib/addPattern.js
+++ b/packages/core/src/lib/addPattern.js
@@ -41,12 +41,7 @@ module.exports = function(pattern, patternlab) {
       patternlab.partials[pattern.patternPartial] = pattern.patternDesc;
     }
 
-    //patterns sorted by name so the patterntype and patternsubtype is adhered to for menu building
-    patternlab.patterns.splice(
-      _.sortedIndexBy(patternlab.patterns, pattern, 'name'),
-      0,
-      pattern
-    );
+    patternlab.patterns.push(pattern);
     patternlab.graph.add(pattern);
   }
 };

--- a/packages/core/src/lib/patternlab.js
+++ b/packages/core/src/lib/patternlab.js
@@ -334,7 +334,12 @@ module.exports = class PatternLab {
         this.patterns.map(pattern => {
           return processIterative(pattern, self);
         })
-      );
+      ).then(() => {
+        // patterns sorted by name so the patterntype and patternsubtype is adhered to for menu building
+        this.patterns.sort((pattern1, pattern2) =>
+          pattern1.name.localeCompare(pattern2.name)
+        );
+      });
     });
   }
 


### PR DESCRIPTION
Closes #975 

Summary of changes:
find all patterns including pseudo patterns and sort them after
retrieving all patterns instead of inject them in the array working on