### PR TITLE
Removed deprecated extend function

### DIFF
--- a/packages/core/src/lib/lineage_hunter.js
+++ b/packages/core/src/lib/lineage_hunter.js
@@ -1,5 +1,4 @@
 'use strict';
-const extend = require('util')._extend;
 const getPartial = require('./get');
 const logger = require('./log');
 
@@ -57,7 +56,7 @@ const lineage_hunter = function() {
             }
 
             ancestorPattern.lineageR.push(lr);
-            extend(patternlab.graph.node(ancestorPattern), lr);
+            Object.assign(patternlab.graph.node(ancestorPattern), lr);
           }
         }
       });


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Summary of changes:

The Node Documentation says that [util._extend](https://nodejs.org/api/util.html#util_util_extend_target_source) function should not be used.

> util._extend(target, source)
> Added in: v0.7.5Deprecated since: v6.0.0
>
>   target <Object>
>   source <Object>
>
> Stability: 0 - Deprecated: Use Object.assign() instead.
>
> The util._extend() method was never intended to be used outside of internal Node.js modules. The community found and used it anyway.
>
> It is deprecated and should not be used in new code. JavaScript comes with very similar built-in functionality through Object.assign().