### PR TITLE
Increase Time Before Stalebot Closes Issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "staged for next release 🏁"


### PR DESCRIPTION
Updates Pattern Lab Node’s stalebot config to increase the amount of time before stalebot closes out a stale issue (as we’ve seen happen a couple times recently). 

This update will at least give folks a little bit more time to catch up on issues (30 days instead of 14) before auto closing.