### PR TITLE
add parameter replacement support for numbers

### DIFF
--- a/packages/core/src/lib/replaceParameter.js
+++ b/packages/core/src/lib/replaceParameter.js
@@ -7,7 +7,7 @@ module.exports = function(template, prop, data) {
 
   const valueRE = new RegExp(`{{{?\\s*[${prop}]+\\s*}?}}`);
 
-  if (typeof data === 'string') {
+  if (typeof data === 'string' || typeof data === 'number') {
     return t.replace(valueRE, data);
   }
 

--- a/packages/core/test/replaceParameter_tests.js
+++ b/packages/core/test/replaceParameter_tests.js
@@ -12,6 +12,12 @@ tap.test('replaces simple value', function(test) {
   test.end();
 });
 
+tap.test('replaces number value', function(test) {
+  const result = replaceParameter('{{count}}', 'count', 12);
+  test.equals(result, '12');
+  test.end();
+});
+
 tap.test('replaces simple boolean true value', function(test) {
   const result = replaceParameter('{{key}}', 'key', true);
   test.equals(result, 'true');


### PR DESCRIPTION
We are currently migrating from php to the node version and facing the issue that number variables aren't supported yet. 

Summary of changes:
replaceParameters.js: adds parameter replacement support for numbers
replaceParameters_tests.js: adds new tests for this case 
