### PR TITLE
fix(edition-twig): correct uikit paths in config

### DIFF
--- a/packages/edition-twig/patternlab-config.json
+++ b/packages/edition-twig/patternlab-config.json
@@ -6,7 +6,7 @@
           "id": "uikit",
           "recursive": true,
           "paths": [
-            "../uikit-workshop/views-twig"
+            "./node_modules/@pattern-lab/uikit-workshop/views-twig"
           ]
         },
         {
@@ -84,11 +84,11 @@
       "annotations": "./source/_annotations/",
       "styleguide": "dist/",
       "patternlabFiles": {
-        "general-header": "../uikit-workshop/views/partials/general-header.mustache",
-        "general-footer": "../uikit-workshop/views/partials/general-footer.mustache",
-        "patternSection": "../uikit-workshop/views/partials/patternSection.mustache",
-        "patternSectionSubtype": "../uikit-workshop/views/partials/patternSectionSubtype.mustache",
-        "viewall": "../uikit-workshop/views/viewall.mustache"
+        "general-header": "views/partials/general-header.mustache",
+        "general-footer": "views/partials/general-footer.mustache",
+        "patternSection": "views/partials/patternSection.mustache",
+        "patternSectionSubtype": "views/partials/patternSectionSubtype.mustache",
+        "viewall": "views/viewall.mustache"
       },
       "js": "./source/js",
       "images": "./source/images",


### PR DESCRIPTION
This corrects the `edition-twig` uikit config paths that were posing a problem when it was used outside the monorepo!

See #1000 #897 