### PR TITLE
UIKit no longer requires the root directory

### DIFF
--- a/packages/uikit-workshop/dist/styleguide/js/patternlab-pattern.js
+++ b/packages/uikit-workshop/dist/styleguide/js/patternlab-pattern.js
@@ -77,7 +77,7 @@
 /******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
 /******/
 /******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "/styleguide/";
+/******/ 	__webpack_require__.p = "./styleguide/";
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/packages/uikit-workshop/dist/styleguide/js/patternlab-viewer.js
+++ b/packages/uikit-workshop/dist/styleguide/js/patternlab-viewer.js
@@ -180,7 +180,7 @@
 /******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
 /******/
 /******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "/styleguide/";
+/******/ 	__webpack_require__.p = "./styleguide/";
 /******/
 /******/ 	// on error function for async loading
 /******/ 	__webpack_require__.oe = function(err) { console.error(err); throw err; };

--- a/packages/uikit-workshop/webpack.config.js
+++ b/packages/uikit-workshop/webpack.config.js
@@ -17,7 +17,7 @@ const defaultConfig = {
   buildDir: './dist',
   prod: false, // or false for local dev
   sourceMaps: true,
-  publicPath: '/styleguide/',
+  publicPath: './styleguide/',
 };
 
 module.exports = async function() {


### PR DESCRIPTION
Fixes 404 when running pattern lab from a non-root directory:
![image](https://user-images.githubusercontent.com/15029/56166478-5741a400-5f9b-11e9-8203-3a6d84504555.png)

After PR:
![image](https://user-images.githubusercontent.com/15029/56166545-8526e880-5f9b-11e9-8bf7-c404ac5e1570.png)

Summary of changes:

- Made the uikit publicPath Relative
