### PR TITLE
Add cachebuster back to footer data

### DIFF
--- a/packages/core/src/lib/compose.js
+++ b/packages/core/src/lib/compose.js
@@ -164,6 +164,7 @@ module.exports = function(pattern, patternlab) {
             logger.info(err);
           }
           allFooterData = _.merge(allFooterData, pattern.jsonFileData);
+          allFooterData.cacheBuster = patternlab.cacheBuster;
           allFooterData.patternLabFoot = footerPartial;
 
           return render(patternlab.userFoot, allFooterData).then(footerHTML => {


### PR DESCRIPTION
Re-implements #948.   

I believe it was accidentally removed in https://github.com/pattern-lab/patternlab-node/commit/42bfe29aeaa68b956110f3b7fe88d6395cf98286#r33265705