### PR TITLE
Fix issues with multiple inline svgs in live-server injection

### DIFF
--- a/packages/live-server/index.js
+++ b/packages/live-server/index.js
@@ -48,10 +48,11 @@ function staticServer(root) {
     var hasNoOrigin = !req.headers.origin;
     var injectCandidates = [
       new RegExp('</body>', 'i'),
-      new RegExp('</svg>'),
+      new RegExp('</svg>', 'g'),
       new RegExp('</head>', 'i'),
     ];
     var injectTag = null;
+    var injectCount = 0;
 
     function directory() {
       var pathname = url.parse(req.originalUrl).pathname;
@@ -62,15 +63,16 @@ function staticServer(root) {
 
     function file(filepath /*, stat*/) {
       var x = path.extname(filepath).toLocaleLowerCase(),
-        match,
+        matches,
         possibleExtensions = ['', '.html', '.htm', '.xhtml', '.php', '.svg'];
       if (hasNoOrigin && possibleExtensions.indexOf(x) > -1) {
         // TODO: Sync file read here is not nice, but we need to determine if the html should be injected or not
         var contents = fs.readFileSync(filepath, 'utf8');
         for (var i = 0; i < injectCandidates.length; ++i) {
-          match = injectCandidates[i].exec(contents);
-          if (match) {
-            injectTag = match[0];
+          matches = contents.match(injectCandidates[i]);
+          injectCount = matches && matches.length || 0;
+          if (injectCount) {
+            injectTag = matches[0];
             break;
           }
         }
@@ -94,7 +96,7 @@ function staticServer(root) {
     function inject(stream) {
       if (injectTag) {
         // We need to modify the length given to browser
-        var len = INJECTED_CODE.length + res.getHeader('Content-Length');
+        var len = INJECTED_CODE.length * injectCount + res.getHeader('Content-Length');
         res.setHeader('Content-Length', len);
         var originalPipe = stream.pipe;
         stream.pipe = function(resp) {


### PR DESCRIPTION
Sets the content-length correctly based on the total number of SVGs contained in the document.

Closes #1011 
