### PR TITLE
fix (#1024): cli build now passes an object instead of a literal

### DIFF
--- a/packages/cli/bin/build.js
+++ b/packages/cli/bin/build.js
@@ -27,11 +27,11 @@ function build(config, options) {
   if (options && options.patternsOnly) {
     // 1
     debug(`build: Building only patterns now into ${config.paths.public.root}`);
-    return patternLab.patternsonly(config.cleanPublic);
+    return patternLab.patternsonly(config);
   } else {
     // 2
     debug(`build: Building your project now into ${config.paths.public.root}`);
-    return patternLab.build(config.cleanPublic);
+    return patternLab.build(config);
   }
 }
 


### PR DESCRIPTION
Closes #1024

Summary of changes:
cli package build script now passes the whole config object instead of a boolean literal to meet the requirements of the patternlab core build and patternsonly methods.