### PR TITLE
feat(starterkits): add starterkit-handlebars-demo

### DIFF
--- a/packages/cli/bin/inquiries/edition.js
+++ b/packages/cli/bin/inquiries/edition.js
@@ -15,19 +15,15 @@ const editionSetup = [
     message: 'Which edition do you want to use (defaults to edition-node)?',
     choices: [
       {
+        name: 'edition-node (handlebars engine)',
+        value: '@pattern-lab/edition-node',
+      },
+      {
         name: 'edition-twig (php engine)',
         value: '@pattern-lab/edition-twig',
       },
       {
-        name: 'edition-node',
-        value: '@pattern-lab/edition-node',
-      },
-      {
-        name: 'edition-node-grunt',
-        value: '@pattern-lab/edition-node-grunt',
-      },
-      {
-        name: 'edition-node-gulp',
+        name: 'edition-node-gulp (legacy)',
         value: '@pattern-lab/edition-node-gulp',
       },
       new inquirer.Separator(),

--- a/packages/cli/bin/inquiries/starterkit.js
+++ b/packages/cli/bin/inquiries/starterkit.js
@@ -10,45 +10,34 @@ const starterkitSetup = [
     message: 'Which starterkit do you want to use?',
     choices: [
       {
-        name: 'starterkit-mustache-demo',
-        value: '@pattern-lab/starterkit-mustache-demo',
+        name: 'starterkit-handlebars-demo [Recommended]',
+        value: '@pattern-lab/starterkit-handlebars-demo',
       },
+      {
+        name: 'starterkit-twig-demo [Recommended]',
+        value: '@pattern-lab/starterkit-twig-demo',
+      },         
       {
         name: 'starterkit-mustache-bootstrap',
         value: 'starterkit-mustache-bootstrap',
-      },
+      },    
+      {
+        name: 'starterkit-mustache-demo',
+        value: '@pattern-lab/starterkit-mustache-demo',
+      },      
       {
         name: 'starterkit-mustache-foundation',
         value: 'starterkit-mustache-foundation',
-      },
-      // {
-      //   name: 'starterkit-twig-base',
-      //   value: 'starterkit-twig-base',
-      // },
-      {
-        name: 'starterkit-twig-demo',
-        value: '@pattern-lab/starterkit-twig-demo',
-      },
+      },      
       {
         name: 'starterkit-mustache-materialdesign',
         value: 'starterkit-mustache-materialdesign',
-      },
-      // {
-      //   name: 'starterkit-twig-drupal-demo',
-      //   value: 'starterkit-twig-drupal-demo',
-      // },
-      // {
-      //   name: 'starterkit-twig-drupal-minimal',
-      //   value: 'starterkit-twig-drupal-minimal',
-      // },
-      {
-        name: 'starterkit-mustache-webdesignday',
-        value: 'starterkit-mustache-webdesignday',
-      },
+      },      
       {
         name: 'starterkit-mustache-base',
         value: '@pattern-lab/starterkit-mustache-base',
       },
+   
       new inquirer.Separator(),
       {
         name: 'Custom starterkit',
@@ -61,8 +50,8 @@ const starterkitSetup = [
       },
     ],
     default: {
-      name: 'starterkit-mustache-base',
-      value: 'starterkit-mustache-base',
+      name: 'starterkit-handlebars-demo',
+      value: 'starterkit-handlebars-demo',
     },
   },
   {

--- a/packages/cli/bin/install-edition.js
+++ b/packages/cli/bin/install-edition.js
@@ -49,11 +49,26 @@ const installEdition = (edition, config, projectDir) => {
       }
       // 4.2
       case '@pattern-lab/edition-node': {
+        const editionPath = path.resolve('./node_modules', edition);
+        const editionConfigPath = path.resolve(
+          editionPath,
+          'patternlab-config.json'
+        );
+
+        const editionConfig = require(editionConfigPath);
+
         pkg.scripts = Object.assign(
           {},
           pkg.scripts || {},
           yield getJSONKey(edition, 'scripts')
         );
+
+        yield copyAsync(
+          path.resolve(editionPath, '/helpers/test.js'),
+          path.resolve(sourceDir, '../', 'helpers/test.js')
+        );
+
+        config = merge(config, editionConfig);
         break;
       }
       // 4.3

--- a/packages/edition-node/README.md
+++ b/packages/edition-node/README.md
@@ -15,7 +15,7 @@ This Edition comes with the following components:
 
 * `@pattern-lab/core`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/core) | [npm](https://www.npmjs.com/package/@pattern-lab/core)
 * `@pattern-lab/cli`: [GitHub](https://github.com/pattern-lab/tree/master/packages/cli) | [npm](https://www.npmjs.com/package/@pattern-lab/cli)
-* `@pattern-lab/engine-mustache`: [GitHub](https://github.com/pattern-lab/tree/master/packages/engine-mustache) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-mustache)
+* `@pattern-lab/engine-handlebars`: [GitHub](https://github.com/pattern-lab/tree/master/packages/engine-handlebars) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-handlebars)
 * `@pattern-lab/uikit-workshop`: [GitHub](https://github.com/pattern-lab/tree/master/packages/uikit-workshop) | [npm](https://www.npmjs.com/package/@pattern-lab/uikit-workshop)
 
 ## Prerequisites

--- a/packages/edition-node/helpers/test.js
+++ b/packages/edition-node/helpers/test.js
@@ -1,0 +1,5 @@
+module.exports = function(Handlebars) {
+  Handlebars.registerHelper('test', function() {
+    return 'This is a test helper';
+  });
+};

--- a/packages/edition-node/package.json
+++ b/packages/edition-node/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@pattern-lab/cli": "^0.0.3",
     "@pattern-lab/core": "^3.0.1",
-    "@pattern-lab/engine-mustache": "^2.0.1-alpha.0",
+    "@pattern-lab/engine-handlebars": "^2.0.0-beta.1",
     "@pattern-lab/uikit-workshop": "^1.0.1"
   },
   "keywords": [

--- a/packages/edition-node/patternlab-config.json
+++ b/packages/edition-node/patternlab-config.json
@@ -68,7 +68,7 @@
       "css": "public/css"
     }
   },
-  "patternExtension": "mustache",
+  "patternExtension": "hbs",
   "patternStateCascade": ["inprogress", "inreview", "complete"],
   "patternExportDirectory": "./pattern_exports/",
   "patternExportPatternPartials": [],
@@ -90,5 +90,10 @@
       "excludedPatternStates": [],
       "excludedTags": []
     }
-  ]
+  ],
+  "engines": {
+    "handlebars": {
+      "extend": "helpers/*.js"
+    }
+  }
 }


### PR DESCRIPTION
@bradfrost's starterkit-handlebars-demo is not showing up during init

![image](https://user-images.githubusercontent.com/298435/63607196-8db9ac00-c597-11e9-8b9e-44b59c9c29fb.png)

this used to be dynamic... but at some point i do not recall appears to be hardcoded.

### Testing

```
cd to/monorepo/packages/cli
npm link
```

then

```
mkdir pl-test-1038
cd pl-test-1038
npm init -y
npm install @pattern-lab/cli
npm link @pattern-lab/cli
npx patternlab init
```

![image](https://user-images.githubusercontent.com/298435/63608972-c65b8480-c59b-11e9-8684-382562c79acb.png)

![image](https://user-images.githubusercontent.com/298435/63608984-cd829280-c59b-11e9-88d0-1ee25ded087d.png)

![image](https://user-images.githubusercontent.com/298435/63609093-091d5c80-c59c-11e9-9456-3ab31ef549de.png)


though these choices are made - the actual code (such as handlebars as the default wont likely be in place until this is released)

