### PR TITLE
UIKit Bug Fixes

### DIFF
--- a/packages/uikit-workshop/src/scripts/components/panels-viewer.js
+++ b/packages/uikit-workshop/src/scripts/components/panels-viewer.js
@@ -117,7 +117,8 @@ export const panelsViewer = {
 
               const templateHighlighted = Prism.highlight(
                 templateFormatted,
-                Prism.languages[panels[i].name.toLowerCase()] || 'markup'
+                Prism.languages[panels[i].name.toLowerCase()] ||
+                  Prism.languages['markup']
                 // Prism.languages[panels[i].name.toLowerCase()],
               );
 

--- a/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-viewport/pl-viewport.js
@@ -393,7 +393,7 @@ class IFrame extends BaseComponent {
       store.getState().app.viewportPx &&
       store.getState().app.viewportPx <= this.clientWidth
         ? store.getState().app.viewportPx + 'px;'
-        : this.clientWidth + 'px;';
+        : '100%';
 
     return (
       <div class="pl-c-viewport pl-js-viewport">


### PR DESCRIPTION
Summary of changes:

1. Fixes an issue in UIKit's Prism.js logic to correctly fall back to using `markup` for syntax highlighting when encountering an unsupported templating language. Addresses a recent bug reported by @thethomic on Gitter.

![image](https://user-images.githubusercontent.com/1617209/64070843-04ab1080-cc3a-11e9-92af-f4d951b8407d.png)

2. Ports over a recent UIkit fix from https://github.com/bolt-design-system/bolt which automatically defaults the viewport resizer to 100% the screen width the very first time PL is opened / if any custom viewport sizes haven't previously been set / when server-side rendering. Addresses one of the issues reported by @cbirdsong on Gitter a couple days ago.

![image](https://user-images.githubusercontent.com/1617209/64070853-64092080-cc3a-11e9-9d30-04acf812d99b.png)

