### PR TITLE
Let any package be installed as a Patternlab starterkit.

### DIFF
--- a/packages/cli/bin/install-starterkit.js
+++ b/packages/cli/bin/install-starterkit.js
@@ -12,8 +12,7 @@ const installStarterkit = (starterkit, config) =>
   wrapAsync(function*() {
     const sourceDir = config.paths.source.root;
     const name = starterkit.value || starterkit;
-    const url = name.startsWith('@pattern-lab/') ? name : `pattern-lab/${name}`;
-    yield checkAndInstallPackage(name, url);
+    yield checkAndInstallPackage(name);
     const kitPath = path.resolve('./node_modules', name);
     yield copyAsync(path.resolve(kitPath, 'dist'), path.resolve(sourceDir));
     let kitConfig;

--- a/packages/cli/bin/utils.js
+++ b/packages/cli/bin/utils.js
@@ -126,16 +126,15 @@ const copyWithPattern = (cwd, pattern, dest) =>
  * @func fetchPackage
  * @desc Fetches and saves packages from npm into node_modules and adds a reference in the package.json under dependencies
  * @param {string} packageName - The package name
- * @param {string} [url] - A URL which will be used to fetch the package from
  */
-const fetchPackage = (packageName, url) =>
+const fetchPackage = packageName =>
   wrapAsync(function*() {
     const useYarn = hasYarn();
     const pm = useYarn ? 'yarn' : 'npm';
     const installCmd = useYarn ? 'add' : 'install';
     try {
-      if (packageName || url) {
-        const cmd = yield spawn(pm, [installCmd, url || packageName]);
+      if (packageName) {
+        const cmd = yield spawn(pm, [installCmd, packageName]);
         error(cmd.stderr);
       }
     } catch (err) {
@@ -150,10 +149,9 @@ const fetchPackage = (packageName, url) =>
  * @func checkAndInstallPackage
  * Checks whether a package for a given packageName is installed locally. If package cannot be found, fetch and install it
  * @param {string} packageName - The package name
- * @param {string} [url] - A URL which will be used to fetch the package from
  * @return {boolean}
  */
-const checkAndInstallPackage = (packageName, url) =>
+const checkAndInstallPackage = packageName =>
   wrapAsync(function*() {
     try {
       require.resolve(packageName);
@@ -162,7 +160,7 @@ const checkAndInstallPackage = (packageName, url) =>
       debug(
         `checkAndInstallPackage: ${packageName} not installed. Fetching it now …`
       );
-      yield fetchPackage(packageName, url);
+      yield fetchPackage(packageName);
       return false;
     }
   });


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #1065 

Summary of changes:
- Drop the check that the package name of the starterkit begins with `@pattern-lab/` namespace.
