### PR TITLE
Fix Handlebars Demo's defaultPattern + Minor UIKit Tweaks

### DIFF
--- a/packages/development-edition-engine-handlebars/patternlab-config.json
+++ b/packages/development-edition-engine-handlebars/patternlab-config.json
@@ -1,7 +1,7 @@
 {
   "cacheBust": true,
   "cleanPublic": true,
-  "defaultPattern": "atoms-swatch",
+  "defaultPattern": "all",
   "defaultShowPatternInfo": false,
   "ishControlsHide": {
     "s": true,

--- a/packages/development-edition-engine-handlebars/patternlab-config.json
+++ b/packages/development-edition-engine-handlebars/patternlab-config.json
@@ -4,9 +4,9 @@
   "defaultPattern": "all",
   "defaultShowPatternInfo": false,
   "ishControlsHide": {
-    "s": true,
-    "m": true,
-    "l": true,
+    "s": false,
+    "m": false,
+    "l": false,
     "full": false,
     "random": true,
     "disco": true,

--- a/packages/uikit-workshop/src/sass/scss/04-components/_pattern.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_pattern.scss
@@ -129,3 +129,7 @@
     max-height: 150rem;
   }
 }
+
+.pl-c-pattern-index {
+  padding: 0 0.5rem;
+}

--- a/packages/uikit-workshop/src/scripts/components/pl-header/pl-header.scss
+++ b/packages/uikit-workshop/src/scripts/components/pl-header/pl-header.scss
@@ -22,12 +22,11 @@ pl-header {
   border-right-color: var(--theme-border, $pl-color-gray-20);
   border-bottom-color: $pl-color-gray-20;
   border-bottom-color: var(--theme-border, $pl-color-gray-20);
-  box-shadow: 0 8px 15px 1px rgba(6, 10, 36, 0.1),0 18px 24px 1px rgba(6, 10, 36, 0.12);
+  box-shadow: 0 8px 15px 1px rgba(6, 10, 36, 0.1);
 
   .pl-c-body--theme-light & {
     color: $pl-color-black;
     background-color: $pl-color-white;
-    border-bottom: 1px solid $pl-color-gray-20;
   }
 
   @media all and (min-width: $pl-bp-med) {

--- a/packages/uikit-workshop/src/scripts/components/pl-logo/pl-logo.scss
+++ b/packages/uikit-workshop/src/scripts/components/pl-logo/pl-logo.scss
@@ -48,7 +48,7 @@ pl-logo {
 .pl-c-logo__img {
   display: block;
   height: auto;
-  max-height: 2.5rem;
+  max-height: 2.063rem; // ~50px max height for the global header
 
   &:not(:last-child){
     margin-right: 0.25rem;


### PR DESCRIPTION
- Updates the Handlebars demo's default pattern config to fix the "empty" page that initially shows up.
- Adds a small amount of inner padding to partially address #1062
- Reduces the global header shadow size just a tad + reduces the max logo height to make the global header's default height a bit more reasonable