### PR TITLE
fix: publish auto-generated “dist” folder when publishing to NPM

### DIFF
--- a/packages/uikit-workshop/package.json
+++ b/packages/uikit-workshop/package.json
@@ -125,5 +125,9 @@
     ">0.25%",
     "ie 11",
     "not op_mini all"
+  ],
+  "files": [
+    "src",
+    "dist"
   ]
 }


### PR DESCRIPTION
Updates the UIKit package.json to tell NPM to publish the auto-generated `dist` folder when publishing. Fixes the missing “dist” folder on NPM reported by @thethomic!

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->