### PR TITLE
UIKIt CSS Hotfix for IE 11

### DIFF
--- a/packages/uikit-workshop/src/sass/scss/02-base/_body.scss
+++ b/packages/uikit-workshop/src/sass/scss/02-base/_body.scss
@@ -10,6 +10,7 @@
 .pl-c-html {
   min-height: 100%;
   display: flex;
+  height: 100%; // fix for IE 11
 }
 
 .pl-c-body {


### PR DESCRIPTION
CSS hotfix for IE 11 to address the main PL container height collapsing.

