### PR TITLE
UIKit Fix: Code Panel Overflow Fix for Firefox

### DIFF
--- a/packages/uikit-workshop/src/sass/pattern-lab.scss
+++ b/packages/uikit-workshop/src/sass/pattern-lab.scss
@@ -65,8 +65,7 @@
   @supports (position: sticky){
     transform: translateY(-0.7rem);
     float: right;
-    position: sticky;
-    top: 1rem;
+    top: 3.2rem;
     right: 0;
     margin-top: -2rem;
   }

--- a/packages/uikit-workshop/src/sass/pattern-lab.scss
+++ b/packages/uikit-workshop/src/sass/pattern-lab.scss
@@ -59,17 +59,8 @@
 .pl-c-code-copy-btn {
   display: inline-block;
   position: absolute;
-  top: 0.5rem;
+  top: 0.4rem;
   right: 0.5rem;
-
-  @supports (position: sticky){
-    transform: translateY(-0.7rem);
-    float: right;
-    top: 3.2rem;
-    right: 0;
-    margin-top: -2rem;
-  }
-
   padding: 0.2rem 0.4rem;
   background-color: $pl-color-gray-07;
   color: $pl-color-gray-87;

--- a/packages/uikit-workshop/src/sass/scss/04-components/_tabs.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_tabs.scss
@@ -92,8 +92,7 @@
   display: flex;
   flex-basis: auto;
   -webkit-overflow-scrolling: touch;
-  height: 100%;
-  overflow: auto; // workaround to firefox background gradient overflow bug
+  overflow-y: auto; // workaround to firefox background gradient overflow bug
 
   /**
      *  Tab content inside modal

--- a/packages/uikit-workshop/src/sass/scss/04-components/_tabs.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_tabs.scss
@@ -93,6 +93,7 @@
   flex-basis: auto;
   -webkit-overflow-scrolling: touch;
   height: 100%;
+  overflow: auto; // workaround to firefox background gradient overflow bug
 
   /**
      *  Tab content inside modal


### PR DESCRIPTION
Small UIKIt CSS fix to address a Firefox rendering quirk reported by @thethomic that was causing the code panel contents to spill out of the container. 

### Before
![image](https://user-images.githubusercontent.com/1617209/69426991-82902c80-0cfc-11ea-857a-4be72ef7ae6b.png)

### After
![image](https://user-images.githubusercontent.com/1617209/69427123-db5fc500-0cfc-11ea-9be6-104b0bce8c19.png)

Closes #1100