### PR TITLE
UIKit Polyfill Hotfix for Edge

### DIFF
--- a/packages/uikit-workshop/src/scripts/patternlab-viewer.modern.js
+++ b/packages/uikit-workshop/src/scripts/patternlab-viewer.modern.js
@@ -1,1 +1,2 @@
+import '@webcomponents/custom-elements/src/custom-elements.js'; // temp workaround for Edge supporting ES modules but not CEs
 import './patternlab-components';


### PR DESCRIPTION
Hotfix workaround to address a gap in our polyfill strategy. Basically the latest version of Edge supports ES modules but NOT custom elements, hence doesn't load the necessary polyfills that non-ES module supporting browsers would normally get.

We need to test and confirm that this workaround works as expected in other modern browsers (Chrome, Safari, FF) — quick testing in Chrome looked fine but just want to double-check before releasing.

Closes #1104
