### PR TITLE
chore: UIKit - referencing 'html-webpack-plugin' from NPM

### DIFF
--- a/packages/uikit-workshop/package.json
+++ b/packages/uikit-workshop/package.json
@@ -91,7 +91,7 @@
     "hogan.js": "^3.0.2",
     "htm": "^1.0.1",
     "html-loader": "^0.5.5",
-    "html-webpack-plugin": "github:jantimon/html-webpack-plugin#webpack-4",
+    "html-webpack-plugin": "^4.0.0-beta.11",
     "iframe-resizer": "^3.6.5",
     "lit-element": "^2.2.1",
     "lit-html": "^1.1.2",


### PR DESCRIPTION
As github might be inaccessible / blocked on some environments (for whatever/security reasons), it's probably better to reference this dependency from NPM instead of Github as well, and solve the problem of referencing to the beta version by its exact upper version number.

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #

Summary of changes:
"html-webpack-plugin" dependency is being retrieved via NPM instead of Github.