### PR TITLE
feat: pass additional configuration into twig-php engine

### DIFF
--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -44,7 +44,7 @@ const engine_twig_php = {
       process.exit(1);
     }
 
-    const { namespaces, alterTwigEnv, relativeFrom } = config.engines.twig;
+    const { namespaces, alterTwigEnv, relativeFrom,  ...rest } = config.engines.twig;
 
     // Schema on config object being passed in:
     // https://github.com/basaltinc/twig-renderer/blob/master/config.schema.json
@@ -55,6 +55,7 @@ const engine_twig_php = {
       },
       relativeFrom,
       alterTwigEnv,
+      ...rest,
     });
 
     // Preserve the namespaces (after recursively adding nested folders) from the config so we can use them later to evaluate partials.


### PR DESCRIPTION
Closes #1117 
https://github.com/pattern-lab/patternlab-node/issues/1117

Summary of changes:
The Php Twig engine can now be fully configured. Any configuration in patternlab-config.engines.twig will be passed down to the twig renderer package.
