### PR TITLE
Update pl-viewport.scss

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.scss
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.scss
@@ -123,7 +123,7 @@ pl-iframe {
   // padding-right: 10px;
   overflow: hidden;
   // border: 1px solid #CCC;
-  border-radius: 5px;
+  border-radius: 0; // Encapsulation does not work with any unit
 
   &.is-ready {
     min-height: 0;


### PR DESCRIPTION
Using a border-radius with any units is creating a odd behavior (on the top left corner) to any iframes used in any patterns in patternlab if there is a need to add a border-radius around the iframe wrapper.

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #

Summary of changes:
