### PR TITLE
Update Pattern Lab's iframe resizer UI to be hidden when iframe is full width

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport-size/pl-viewport-size.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport-size/pl-viewport-size.js
@@ -48,7 +48,7 @@ class ViewportSize extends BaseLitComponent {
 
   updated() {
     if (this.viewport && this.viewport.bodySize) {
-      this.em = Math.floor(this.px - 40 * this.bodySize);
+      this.em = Math.floor(this.px * this.bodySize);
     }
   }
 
@@ -56,7 +56,7 @@ class ViewportSize extends BaseLitComponent {
     if (!window.__PRERENDER_INJECTED) {
       return html`
         <form class="pl-c-viewport-size" method="post" action="#">
-          <span class="pl-c-viewport-size__input">${this.px - 40}px</span
+          <span class="pl-c-viewport-size__input">${this.px}px</span
           >&nbsp;/&nbsp;
           <span class="pl-c-viewport-size__input">${this.em}em</span>
         </form>

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.scss
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.scss
@@ -82,8 +82,8 @@ pl-iframe {
   min-width: 240px;
   max-width: 100vw;
   background: $pl-viewport-bg;
-  padding-right: $pl-resizer-width;
-  padding-left: $pl-resizer-width;
+  padding-right: 0;
+  padding-left: 0;
   // box-shadow: 0 3px 6px rgba(21,22,25,.16), 0 3px 6px rgba(21,22,25,.23);
 
   &.hay-mode {
@@ -153,7 +153,7 @@ pl-iframe {
 .pl-c-viewport__resizer {
   position: absolute;
   width: $pl-resizer-width;
-  right: 0;
+  right: $pl-resizer-width * -1;
   top: 0;
   bottom: 0;
   margin: 0;


### PR DESCRIPTION
![CleanShot 2020-03-01 at 14 31 11](https://user-images.githubusercontent.com/1617209/75632472-5f61fc80-5bca-11ea-94ce-dacaf27dd71a.gif)

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

## Summary of changes:
Updates the iFrame resizer UI so the resizer handle no longer shows up when the iframe is "full width" -- per feedback / recommendation from @bradfrost 😉  