### PR TITLE
fix: actually exit build when Twig render fails

### DIFF
--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -91,8 +91,16 @@ const engine_twig_php = {
           if (results.ok) {
             resolve(results.html + details);
           } else {
-            console.log(results.message);
-            process.exit(1);
+            // make Twig rendering errors more noticeable + exit when not in dev mode (or running the `patternlab serve` command)
+            if (
+              process.argv.slice(1).includes('serve') ||
+              process.env.NODE_ENV === 'development'
+            ) {
+              reject(chalk.red(results.message));
+            } else {
+              console.log(chalk.red(results.message));
+              process.exit(1);
+            }
           }
         })
         .catch(error => {

--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -17,6 +17,7 @@
 const TwigRenderer = require('@basalt/twig-renderer');
 const fs = require('fs-extra');
 const path = require('path');
+const chalk = require('chalk');
 
 let twigRenderer;
 let patternLabConfig = {};

--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -90,7 +90,8 @@ const engine_twig_php = {
           if (results.ok) {
             resolve(results.html + details);
           } else {
-            reject(results.message);
+            console.log(results.message);
+            process.exit(1);
           }
         })
         .catch(error => {

--- a/packages/engine-twig-php/package.json
+++ b/packages/engine-twig-php/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@basalt/twig-renderer": "0.13.1",
     "@pattern-lab/core": "^5.7.0",
+    "chalk": "^4.0.0",
     "fs-extra": "0.30.0"
   },
   "keywords": [


### PR DESCRIPTION
Before these changes, when a Twig syntax error was encountered (like using an incorrect function or filter), the error message would be displayed in the Terminal output but would say the build happened ok. The error messages from the Twig Renderer come out like "Error trying to render "01-components/card/05-card.twig". Unknown "render" filter.". After these changes, it displays the error message and then exits non-zero, which stops the output right where the dev can see the issue (either in watch mode or in CI builds).