### PR TITLE
fix(cli): set current working directory before scaffolded npm init

### DIFF
--- a/packages/cli/bin/scaffold.js
+++ b/packages/cli/bin/scaffold.js
@@ -16,8 +16,11 @@ const mkdirsAsync = require('./utils').mkdirsAsync;
  */
 const scaffold = (projectDir, sourceDir, publicDir, exportDir) =>
   wrapAsync(function*() {
-    if (!fs.existsSync(path.resolve(projectDir, 'package.json'))) {
-      execa.sync('npm', ['init', '-y']);
+    const projectPath = path.join(process.cwd(), projectDir);
+    if (!fs.existsSync(path.join(projectPath, 'package.json'))) {
+      execa.sync('npm', ['init', '-y'], {
+        cwd: projectPath,
+      });
     }
     /**
      * Create mandatory files structure


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #1142 

Summary of changes:

In my testing of production, running `npm init patternlab` prompts you to choose a directory,

If you choose to specify a directory (assuming to create a new one, in this case, we check for the presence of a `package.json` but then don't use that same path to run `npm init` if one is not found. Sure enough, the `package.json` is created in the calling directory, not the new one.

This change Attempts to set current working directory prior to project init.

I tried getting the scaffold tests to work but could not in limited time.


