### PR TITLE
fix(core): do not warn about uikit-polyfills

### DIFF
--- a/packages/core/src/lib/loaduikits.js
+++ b/packages/core/src/lib/loaduikits.js
@@ -37,19 +37,20 @@ const readModuleFile = (kit, subPath) => {
 /**
  * Loads uikits, connecting configuration and installed modules
  * [1] Looks in node_modules for uikits.
- * [2] Only continue if uikit is enabled in patternlab-config.json
- * [3] Reads files from uikit that apply to every template
+ * [2] Filter out our uikit-polyfills package.
+ * [3] Only continue if uikit is enabled in patternlab-config.json
+ * [4] Reads files from uikit that apply to every template
  * @param {object} patternlab
  */
 module.exports = patternlab => {
   const paths = patternlab.config.paths;
 
-  const uikits = findModules(nodeModulesPath, isUIKitModule); // [1]
-
+  const uikits = findModules(nodeModulesPath, isUIKitModule) // [1]
+    .filter(kit => kit.name !== 'polyfills'); // [2]
   uikits.forEach(kit => {
     const configEntry = _.find(_.filter(patternlab.config.uikits, 'enabled'), {
       name: `uikit-${kit.name}`,
-    }); // [2]
+    }); // [3]
 
     if (!configEntry) {
       logger.warning(
@@ -83,7 +84,7 @@ module.exports = patternlab => {
           paths.source.patternlabFiles.patternSectionSubtype
         ),
         viewAll: readModuleFile(kit, paths.source.patternlabFiles.viewall),
-      }; // [3]
+      }; // [4]
     } catch (ex) {
       logger.error(ex);
       logger.error(

--- a/packages/core/test/loaduitkits_tests.js
+++ b/packages/core/test/loaduitkits_tests.js
@@ -3,6 +3,7 @@
 const tap = require('tap');
 const rewire = require('rewire');
 
+const logger = require('../src/lib/log');
 const loaduikits = rewire('../src/lib/loaduikits');
 
 const testConfig = require('./util/patternlab-config.json');
@@ -21,6 +22,10 @@ const findModulesMock = function() {
       name: 'baz',
       modulePath: 'node_modules/@pattern-lab/uikit-baz',
     },
+    {
+      name: 'polyfills',
+      modulePath: 'node_modules/@pattern-lab/uikit-polyfills',
+    },
   ];
 };
 
@@ -35,11 +40,40 @@ loaduikits.__set__({
   fs: fsMock,
 });
 
+logger;
+
+tap.test('loaduitkits - does not warn on uikit-polyfills', test => {
+  //arrange
+  const patternlab = {
+    config: testConfig,
+    uikits: {},
+  };
+
+  patternlab.config.logLevel = 'warning';
+  logger.log.on('warning', msg => test.notOk(msg.includes('uikit-polyfills')));
+
+  const uikitFoo = {
+    name: 'uikit-foo',
+    enabled: true,
+    outputDir: 'foo',
+    excludedPatternStates: ['legacy'],
+    excludedTags: ['baz'],
+  };
+
+  patternlab.config.uikits = [uikitFoo];
+
+  //act
+  loaduikits(patternlab).then(() => {
+    logger.warning = () => {};
+    test.done();
+  });
+});
+
 tap.test('loaduikits - maps fields correctly', function(test) {
   //arrange
   const patternlab = {
     config: testConfig,
-    uikits: [],
+    uikits: {},
   };
 
   const uikitFoo = {
@@ -78,7 +112,7 @@ tap.test('loaduikits - only adds files for enabled uikits', function(test) {
   //arrange
   const patternlab = {
     config: testConfig,
-    uikits: [],
+    uikits: {},
   };
 
   patternlab.config.uikits = [


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #1104 

Summary of changes:

Filters out `uikit-polyfills` from `loaduikits.js`, so that the warning about its presence never occurs. 
Added test asserting behavior.