### PR TITLE
Feature/fix broken links

### DIFF
--- a/packages/docs/src/_data/navigation.json
+++ b/packages/docs/src/_data/navigation.json
@@ -47,10 +47,6 @@
 	],
 	"footerNav": [
 		{
-			"label": "Documentation",
-			"url": "/docs"
-		},
-		{
 			"label": "Resources",
 			"url": "/resources"
 		},

--- a/packages/docs/src/_includes/layouts/home.njk
+++ b/packages/docs/src/_includes/layouts/home.njk
@@ -84,7 +84,7 @@
         
         {% set styleModifier = 'c-tile--orange' %}
         {% set title = 'Open source and community driven' %}
-        {% set link = '#' %}
+        {% set link = '/support' %}
         {% set description = "Pattern Lab is (and will always be) an open source project. Check out the project on <a href='https://github.com/pattern-lab/patternlab-node'>GitHub</a> and join the <a href='https://gitter.im/pattern-lab/home'>Pattern Lab Gitter community</a> for conversation and support." %}
         {% include "components/tile.njk" %}
 

--- a/packages/docs/src/_includes/layouts/page-base.njk
+++ b/packages/docs/src/_includes/layouts/page-base.njk
@@ -1,0 +1,24 @@
+{% extends 'layouts/base.njk' %}
+{% set pageType = 'Resources' %}
+
+{# Intro content #}
+{% set introHeading = title %}
+{% set introSummary %}
+
+{% endset %}
+
+{% block content %}
+  <div class="l-container">
+    <div class="l-linelength-container">
+      <article>
+        {% include "components/page-header.njk" %}
+        <div class="c-text-passage">
+          {{ content | safe }}
+        </div>
+        
+      </article>
+    </div>
+  </div>
+{% endblock %}
+
+{{ content | safe }}

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -29,7 +29,7 @@ Sets whether or not to delete `public.patterns/` upon each build of Pattern Lab.
 
 ### defaultPattern
 
-Sets a specific pattern upon launch of the styleguide. This pattern will not be available in the navigation, or in view all pages. The only way to get to it will be via a refresh. Set it using the [short-hand pattern-include syntax](http://localhost:4000/docs/pattern-including.html):
+Sets a specific pattern upon launch of the styleguide. This pattern will not be available in the navigation, or in view all pages. The only way to get to it will be via a refresh. Set it using the [short-hand pattern-include syntax](/docs/including-patterns/):
 
 ```javascript
 "defaultPattern": "pages-welcome",
@@ -160,7 +160,7 @@ Sets the panel name and language for the code tab on the styleguide. Since this 
 
 ### patternStateCascade
 
-See the [Pattern State Documentation](http://patternlab.io/docs/pattern-states.html#node)
+See the [Pattern State Documentation](/docs/using-pattern-states/)
 
 **default**:
 
@@ -176,7 +176,7 @@ Sets the location that any export operations should output files to. This may be
 
 ### patternExportPatternPartials
 
-Sets an array of patterns (using the [short-hand pattern-include syntax](http://localhost:4000/docs/pattern-including.html)) to be exported after a build.
+Sets an array of patterns (using the [short-hand pattern-include syntax](/docs/including-patterns/)) to be exported after a build.
 
 For example, to export the navigation, header, and footer, one might do:
 
@@ -200,7 +200,7 @@ Sets live-server options. See the [live-server documentation](https://github.com
 
 ### starterkitSubDir
 
-[Starterkits](http://localhost:4000/docs/advanced-starterkits.html) by convention house their files within the `dist/` directory. Should someone ever wish to change this, this key is available.
+[Starterkits](/docs/starterkits/) by convention house their files within the `dist/` directory. Should someone ever wish to change this, this key is available.
 
 **default**:
 
@@ -251,7 +251,7 @@ See the [initial release notes](https://github.com/pattern-lab/styleguidekit-ass
 
 ### uikits
 
-Introduced in Pattern Lab Node v3, UIKits are a new term in the Pattern Lab [Ecosystem](http://patternlab.io/docs/advanced-ecosystem-overview.html). They are an evolution of the original Styleguidekit pattern which separated front-end templates from front-end assets like stylesheets and code. The existing `styleguidekit-assets-default` and `styleguidekit-mustache-default` have merged into `uikit-workshop`.
+Introduced in Pattern Lab Node v3, UIKits are a new term in the Pattern Lab [Ecosystem](/docs/overview-of-pattern-lab's-ecosystem/). They are an evolution of the original Styleguidekit pattern which separated front-end templates from front-end assets like stylesheets and code. The existing `styleguidekit-assets-default` and `styleguidekit-mustache-default` have merged into `uikit-workshop`.
 
 `uikits` accepts an array of UIKit objects, shipping with the one above.
 

--- a/packages/docs/src/docs/advanced-ecosystem-overview.md
+++ b/packages/docs/src/docs/advanced-ecosystem-overview.md
@@ -35,7 +35,7 @@ Have a trusty set of boilerplate code that you start every project with? Perhaps
 
 Importing a starterkit is only a few keystrokes away after installation.
 
-[Learn more about Starterkits](/docs/advanced-starterkits.html#node)
+[Learn more about Starterkits](/docs/starterkits/)
 
 ### StyleguideKits
 
@@ -55,4 +55,4 @@ The flexibility of the Pattern Lab ecosystem means that teams can develop tools 
 
 ## Guidance and Help
 
-If you have ideas or would like guidance before we have all of the documentation done please learn how you can [engage with the Pattern Lab community](/contribute.html).
+If you have ideas or would like guidance before we have all of the documentation done please learn how you can [engage with the Pattern Lab community](/support/).

--- a/packages/docs/src/docs/advanced-integration-with-grunt.md
+++ b/packages/docs/src/docs/advanced-integration-with-grunt.md
@@ -11,8 +11,6 @@ eleventyNavigation:
 
 **Note:** _These directions may be incomplete. They also require **v0.7.9** of the PHP version of Pattern Lab._
 
-# Integration with Grunt
-
 Setting up Grunt to work with the PHP version of Pattern Lab should be straightforward. To do so please do the following:
 
 1. Open a terminal window

--- a/packages/docs/src/docs/advanced-starterkits.md
+++ b/packages/docs/src/docs/advanced-starterkits.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   order: 300
 ---
 
-Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/advanced-ecosystem-overview.html) An agency or team could use it for each new client or project. [Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design.
+Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/overview-of-pattern-lab's-ecosystem/) An agency or team could use it for each new client or project. [Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design.
 
 ## Structure
 
@@ -27,7 +27,7 @@ js/
 favicon.ico
 ```
 
-Teams constructing their own Starterkits should stick to this structure if they wish to publish it externally, else may alter the structure to their [configured `paths`](/docs/advanced-config-options.html#node).
+Teams constructing their own Starterkits should stick to this structure if they wish to publish it externally, else may alter the structure to their [configured `paths`](/docs/editing-the-configuration-options/).
 
 ## Installing Starterkits
 

--- a/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
+++ b/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   order: 300
 ---
 
-By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/pattern-parameters.html). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.
+By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/using-pattern-parameters/). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.
 
 Right now the most mature PatternEngines are Handlebars, Mustache and Twig.
 

--- a/packages/docs/src/docs/data-link-variable.md
+++ b/packages/docs/src/docs/data-link-variable.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   order: 100
 ---
 
-# Linking to Patterns with Pattern Lab's Default `link` Variable
-
 You can build patterns that link to one another to help simulate using a real website. This is especially useful when working with the Pages and Templates pattern types. Rather than having to remember the actual path to a pattern you can use the same shorthand syntax you'd use to include one pattern within another. **Important:** Pattern links _do not_ support the same fuzzy matching of names as the shorthand partials syntax does. The basic format is:
 
 ```html

--- a/packages/docs/src/docs/data-overview.md
+++ b/packages/docs/src/docs/data-overview.md
@@ -20,12 +20,12 @@ The Node version of Pattern Lab only supports JSON.
 There are three places to store data in Pattern Lab:
 
 - in `./source/_data`.
-- in [pattern-specific](/docs/data-pattern-specific.html) files in `./source/_patterns`.
-- in [pseudo-pattern](/docs/pattern-pseudo-patterns.html) files in `./source/_patterns`.
+- in [pattern-specific](/docs/creating-pattern-specific-values/) files in `./source/_patterns`.
+- in [pseudo-pattern](/docs/using-pseudo-patterns/) files in `./source/_patterns`.
 
 ### A Special Note About Pattern Parameters
 
-[Pattern parameters](/docs/pattern-parameters.html) are a simple find and replace of variables in the included pattern. As such they do not affect the context stack of Mustache and we don't consider them true data. They have no impact on overall data inheritance and they cannot be used any deeper than the included pattern. They are a hack.
+[Pattern parameters](/docs/using-pattern-parameters/) are a simple find and replace of variables in the included pattern. As such they do not affect the context stack of Mustache and we don't consider them true data. They have no impact on overall data inheritance and they cannot be used any deeper than the included pattern. They are a hack.
 
 ## Data Inheritance
 

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -9,16 +9,16 @@ eleventyNavigation:
   order: 20
 ---
 
-When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/pattern-managing-assets.html). Each time [your site is generated](/docs/generating-pattern-lab.html) your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.
+When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/managing-pattern-assets/). Each time your site is generated your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.
 
 ## Pattern Lab Directories
 
 For the most part you can organize `./source/` anyway you see fit. There are a few Pattern Lab-specific directories though. They are:
 
-- `_annotations/` - where your annotations reside. [learn more](/docs/pattern-adding-annotations.html).
-- `_data/` - where the global data used to render your patterns resides. [learn more](/docs/data-overview.html).
-- `_meta/` - where the header and footer that get applied to all of your patterns resides. [learn more](/docs/pattern-header-footer.html).
-- `_patterns/` - where your patterns, pattern documentation, and pattern-specific data reside. [learn more](/docs/pattern-organization.html).
+- `_annotations/` - where your annotations reside. [learn more](/docs/adding-annotations/).
+- `_data/` - where the global data used to render your patterns resides. [learn more](/docs/overview-of-data/).
+- `_meta/` - where the header and footer that get applied to all of your patterns resides. [learn more](/docs/modifying-the-pattern-header-and-footer/).
+- `_patterns/` - where your patterns, pattern documentation, and pattern-specific data reside. [learn more](/docs/reorganizing-patterns/).
 
 ## Configuring Pattern Lab Directories
 
@@ -77,4 +77,4 @@ In the Node version of Pattern Lab you can modify the following configuration op
 
 ## Watching for Source File Changes
 
-Manually generating the Pattern Lab website after each change can be cumbersome. The Node version of Pattern Lab comes with the ability to [watch files in the `./source/` directory for changes and re-generate the site automatically](/docs/advanced-auto-regenerate.html). The Pattern Lab website can also be [automatically reloaded](/docs/advanced-reload-browser.html).
+Manually generating the Pattern Lab website after each change can be cumbersome. The Node version of Pattern Lab comes with the ability to watch files in the `./source/` directory for changes and re-generate the site automatically. The Pattern Lab website can also be automatically reloaded..

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -38,7 +38,7 @@ This will bring up an installation menu that presents the following steps:
 
 ## Step 5: Choose initial patterns
 
-**`What initial patterns do you want included in your project?`** - Choose the <a href="/docs/advanced-starterkits.html">Starterkit</a> you want to begin your project with. The options are:
+**`What initial patterns do you want included in your project?`** - Choose the <a href="/docs/starterkits/">Starterkit</a> you want to begin your project with. The options are:
 
 - **`Handlebars base patterns`** `(some basic patterns to get started with)` - TODO: include demo link
 - **`Handlebars demo patterns`** `(full demo website and patterns)` - TODO: include demo link
@@ -50,4 +50,3 @@ This will bring up an installation menu that presents the following steps:
 
 **`Are you happy with your choices? (Hit enter for YES)?`** - Confirm your choices, and when done the Pattern Lab installation will begin.
 
-Once installation is complete, you're ready to <a href="/docs/generating-pattern-lab.html">generate Pattern Lab for the first time.</a>

--- a/packages/docs/src/docs/pattern-add-new.md
+++ b/packages/docs/src/docs/pattern-add-new.md
@@ -22,4 +22,4 @@ If we want to add a new pattern we simply tack it onto the end:
     media-block.mustache
     new-pattern.mustache
 
-If you want more control over their ordering please refer to "[Reorganizing Patterns](/docs/pattern-reorganizing.html)."
+If you want more control over their ordering please refer to "[Reorganizing Patterns](/docs/reorganizing-patterns/)."

--- a/packages/docs/src/docs/pattern-converting.md
+++ b/packages/docs/src/docs/pattern-converting.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   order: 190
 ---
 
-You may have invested time in building patterns for Brad's original edition of Pattern Lab but now want to convert them so they can be used with the new PHP version of Pattern Lab. To convert them all you need to do is swap out the old `inc()` calls for the Mustache-based [shorthand partials syntax](/docs/pattern-including.html). For example, let's say this was a call to a pattern using the original syntax:
+You may have invested time in building patterns for Brad's original edition of Pattern Lab but now want to convert them so they can be used with the new PHP version of Pattern Lab. To convert them all you need to do is swap out the old `inc()` calls for the Mustache-based [shorthand partials syntax](/docs/including-patterns/). For example, let's say this was a call to a pattern using the original syntax:
 
     <?php inc('atom','logo') ?>
 

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -30,7 +30,7 @@ We'd name our documentation file:
 
 ## Documenting Pseudo-Patterns
 
-To add documentation to [pseudo-patterns](/docs/pattern-pseudo-patterns.html), replace the tilde sign (`~`) with a dash (`-`) when naming your documentation file.
+To add documentation to [pseudo-patterns](/docs/using-pseudo-patterns/), replace the tilde sign (`~`) with a dash (`-`) when naming your documentation file.
 
 For example, to document the following pseudo-pattern:
 

--- a/packages/docs/src/docs/pattern-including.md
+++ b/packages/docs/src/docs/pattern-including.md
@@ -44,7 +44,7 @@ The shorthand syntax also allows for fuzzy matching on pattern names. This means
 _Warning:_ Because subtypes are not included in the shorthand include syntax a given pattern name needs to be unique within its _pattern type_ and not just its pattern subtype. If you run into this problem you can do one of two things:
 
 - use the default include syntax for your template language or
-- give your pattern a unique name and use [the pattern's documentation](/docs/pattern-documentation.html) to provide the pattern name
+- give your pattern a unique name and use [the pattern's documentation](/docs/documenting-patterns/) to provide the pattern name
 
 ## The Default Include Syntax
 

--- a/packages/docs/src/docs/pattern-linking.md
+++ b/packages/docs/src/docs/pattern-linking.md
@@ -20,7 +20,7 @@ Pattern Lab comes with support for a number of special query string variables to
 
 ## <span id="link-pattern"></span>Linking to Specific Patterns
 
-You can link directly to any pattern listed on the Pattern Lab website. This might be useful when asking clients for feedback on a particular template or page pattern. If you want to [link from one pattern to another use the `link` variable](/docs/data-link-variable.html).
+You can link directly to any pattern listed on the Pattern Lab website. This might be useful when asking clients for feedback on a particular template or page pattern. If you want to [link from one pattern to another use the `link` variable](/docs/linking-to-patterns-with-pattern-lab's-default-link-variable/).
 
 ### Copy & Paste
 
@@ -34,7 +34,7 @@ It's also very easy to create a link manually. Simply append `?p=pattern-name` t
 ?p=templates-article
 ```
 
-The direct link feature supports the [shorthand partials syntax](/docs/pattern-including.html) found in the Node version of Pattern Lab. Just provide part of a pattern name and Pattern Lab will attempt to resolve it.
+The direct link feature supports the [shorthand partials syntax](/docs/including-patterns/) found in the Node version of Pattern Lab. Just provide part of a pattern name and Pattern Lab will attempt to resolve it.
 
 ## <span id="default-width"></span>Setting the Default Width for the Viewport
 

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -13,7 +13,7 @@ Assets for patterns - including JavaScript, CSS, and images - should be stored a
 
 Pattern Lab ships with copy tasks in the `Gruntfile.js` or `Gulpfile.js` of [the Editions](https://github.com/pattern-lab/?utf8=%E2%9C%93&query=edition-node) that copy your assets for you.
 
-This structure is meant to be extended to suit your purposes. Change targets, move files, or ignore certain filetypes altogether. **Note**: If you make changes to `Gruntfile.js` or `Gulpfile.js`, such as to copy a new directory, and have [auto re-generation and browser reload enabled](/docs/advanced-auto-regenerate.html#node), you will need to stop and start your tasks to pick up the changes.
+This structure is meant to be extended to suit your purposes. Change targets, move files, or ignore certain filetypes altogether. **Note**: If you make changes to `Gruntfile.js` or `Gulpfile.js`, such as to copy a new directory, and have auto re-generation and browser reload enable, you will need to stop and start your tasks to pick up the changes.
 
 ## Configuring Asset Locations
 
@@ -52,4 +52,4 @@ Note how some sets of files even extend into the "vendor" `./node_modules/` dire
 
 ## Adding Assets to the Pattern Header &amp; Footer
 
-Static assets like Javascript and CSS **are not** added automagically to your patterns. You need to add them manually to the [shared pattern header and footer](/docs/advanced-auto-regenerate.html#node).
+Static assets like Javascript and CSS **are not** added automagically to your patterns. You need to add them manually to the [shared pattern header and footer](/docs/modifying-the-pattern-header-and-footer/).

--- a/packages/docs/src/docs/pattern-organization.md
+++ b/packages/docs/src/docs/pattern-organization.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   order: 10
 ---
 
-Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/advanced-template-language-and-pattern-engines.html).
+Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/template-language-and-patternengines/).
 
 ## How Patterns Are Organized
 
@@ -32,11 +32,11 @@ You do **not** have to use the Atomic Design naming convention when organizing y
 
 ## Ordering
 
-By default, pattern types, pattern subtypes and patterns are ordered alphabetically. If you want more control over their ordering please refer to "[Reorganizing Patterns](/docs/pattern-reorganizing.html)."
+By default, pattern types, pattern subtypes and patterns are ordered alphabetically. If you want more control over their ordering please refer to "[Reorganizing Patterns](/docs/reorganizing-patterns/)."
 
 ## Deeper Nesting
 
-Node versions support nesting of folders under `patternSubtype`. For example, you may want to organize your [pattern documentation](/docs/pattern-documenting.html), pattern, Sass files and [pseudo-patterns](/docs/pattern-pseudo-patterns.html) in one directory like so:
+Node versions support nesting of folders under `patternSubtype`. For example, you may want to organize your [pattern documentation](/docs/documenting-patterns/), pattern, Sass files and [pseudo-patterns](/docs/using-pseudo-patterns/) in one directory like so:
 
     - molecules/
       - blocks/
@@ -49,4 +49,4 @@ Node versions support nesting of folders under `patternSubtype`. For example, yo
 
 In this example the `media-block/` directory is ignored for the purposes of generating breadcrumbs and navigation in the Pattern Lab front-end but the documentation, pattern and pseudo-patterns are still rendered.
 
-Folders can be nested under `media-block/` if desired but this is discouraged because of possible collisions when using the [shorthand partial syntax](http://patternlab.io/docs/pattern-including.html).
+Folders can be nested under `media-block/` if desired but this is discouraged because of possible collisions when using the [shorthand partial syntax](/docs/including-patterns/).

--- a/packages/docs/src/docs/pattern-pseudo-patterns.md
+++ b/packages/docs/src/docs/pattern-pseudo-patterns.md
@@ -13,17 +13,17 @@ Pseudo-patterns give developers and designers the ability to quickly build multi
 
 ## The Pseudo-Pattern File Naming Convention
 
-Pseudo-patterns are similar to [pattern-specific JSON files](/docs/data-pattern-specific.html) but are hinted in such a way that a developer can build a variant of an existing pattern. The basic syntax:
+Pseudo-patterns are similar to [pattern-specific JSON files](/docs/creating-pattern-specific-values/) but are hinted in such a way that a developer can build a variant of an existing pattern. The basic syntax:
 
     patternName~pseudo-pattern-name.json
 
-The tilde (`~`) and `.json` file extension are the hints that Pattern Lab uses to determine that this is a pseudo-pattern. The `patternName` tells Pattern Lab which existing pattern it should use when rendering the pseudo-pattern. The JSON file itself works exactly like the [pattern-specific JSON file](/docs/data-pattern-specific.html). It has the added benefit that the pseudo-pattern will also inherit any values from the existing pattern's pattern-specific JSON file.
+The tilde (`~`) and `.json` file extension are the hints that Pattern Lab uses to determine that this is a pseudo-pattern. The `patternName` tells Pattern Lab which existing pattern it should use when rendering the pseudo-pattern. The JSON file itself works exactly like the [pattern-specific JSON file](/docs/creating-pattern-specific-values/). It has the added benefit that the pseudo-pattern will also inherit any values from the existing pattern's pattern-specific JSON file.
 
 From a navigation and naming perspective `patternName` and `pseudoPatternName` will be combined.
 
 ## Adding Pseudo-Patterns to Your Project
 
-Adding a pseudo-pattern is as simple as naming it correctly and following the [pattern-specific JSON file](/docs/data-pattern-specific.html) instructions for organizing its content. Let's look at a simple example where we want to show an emergency notification on our homepage Mustache template. Our `03-templates/` directory might look like this:
+Adding a pseudo-pattern is as simple as naming it correctly and following the [pattern-specific JSON file](/docs/creating-pattern-specific-values/) instructions for organizing its content. Let's look at a simple example where we want to show an emergency notification on our homepage Mustache template. Our `03-templates/` directory might look like this:
 
     article.mustache
     blog.mustache
@@ -66,8 +66,8 @@ By default, pseudo-patterns **cannot** be used as pattern includes. The data inc
 
 ## Re-ordering Pseudo-Patterns
 
-To learn how to re-order pseudo-patterns, check the documentation for [Reorganizing Patterns](/docs/pattern-reorganizing.html).
+To learn how to re-order pseudo-patterns, check the documentation for [Reorganizing Patterns](/docs/reorganizing-patterns/).
 
 ## Documenting Pseudo-Patterns
 
-To learn how to document pseudo-patterns, check the documentation for [Documenting Patterns](/docs/pattern-documenting.html) to learn more.
+To learn how to document pseudo-patterns, check the documentation for [Documenting Patterns](/docs/documenting-patterns/) to learn more.

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -1,5 +1,5 @@
 ---
-layout: layouts/docs.njk
+layout: layouts/page-base.njk
 title: Resources
 ---
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #1153 

Summary of changes:
- https://patternlab-docs-preview.netlify.app/docs/pattern-reorganizing.html has changed to https://patternlab-docs-preview.netlify.app/docs/reorganizing-patterns/
- "Resources" page now points to the proper directory.
- https://patternlab-docs-preview.netlify.app/docs no longer exists because it is a part of the nav now.
- https://patternlab-docs-preview.netlify.app/docs/advanced-auto-regenerate.html no longer exists
- https://patternlab-docs-preview.netlify.app/docs/pattern-including.html has been changed to https://patternlab-docs-preview.netlify.app/docs/including-patterns/

All of the other patternlab.io links from the current site have been renamed in the new site or removed altogether.