### PR TITLE
Fix plugin-tabs enabling multiple file formats #1163

### DIFF
--- a/packages/plugin-tab/dist/js/@pattern-lab-plugin-tab.js
+++ b/packages/plugin-tab/dist/js/@pattern-lab-plugin-tab.js
@@ -6,6 +6,15 @@ window.PluginTab = {
   init: function() {
     //placeholder that will be replaced during configuation
     //most plugins could probably just implement logic here instead.
-    /*SNIPPETS*/
+    function addPanels() {
+      /*SNIPPETS*/
+    }
+
+    // workaround to try recovering from load order race conditions
+    if (window.patternlab && window.patternlab.panels) {
+      addPanels();
+    } else {
+      document.addEventListener('patternLab.pageLoad', addPanels);
+    }
   },
 };

--- a/packages/plugin-tab/src/snippet.js
+++ b/packages/plugin-tab/src/snippet.js
@@ -8,6 +8,6 @@ window.patternlab.panels.add({
   httpRequestCompleted: false,
   prismHighlight: true,
   language: '<<type>>'//,
-  /* TODO: We would need to find a way to enable keyCombo for multiple fields
+  /* TODO: We would need to find a way to enable keyCombo for multiple panels
   keyCombo: 'ctrl+shift+z',*/
 });

--- a/packages/plugin-tab/src/snippet.js
+++ b/packages/plugin-tab/src/snippet.js
@@ -1,21 +1,13 @@
-function addPanels() {
-  window.patternlab.panels.add({
-    id: 'sg-panel-scss',
-    name: 'SCSS',
-    default: false,
-    templateID: 'pl-panel-template-code',
-    httpRequest: true,
-    httpRequestReplace: '.scss',
-    httpRequestCompleted: false,
-    prismHighlight: true,
-    language: 'scss',
-    keyCombo: 'ctrl+shift+z',
-  });
-}
-
-// workaround to try recovering from load order race conditions
-if (window.patternlab && window.patternlab.panels) {
-  addPanels();
-} else {
-  document.addEventListener('patternLab.pageLoad', addPanels);
-}
+window.patternlab.panels.add({
+  id: 'sg-panel-<<type>>',
+  name: '<<typeUC>>',
+  default: window.config.defaultPatternInfoPanelCode && window.config.defaultPatternInfoPanelCode === "<<type>>",
+  templateID: 'pl-panel-template-code',
+  httpRequest: true,
+  httpRequestReplace: '.<<type>>',
+  httpRequestCompleted: false,
+  prismHighlight: true,
+  language: '<<type>>'//,
+  /* TODO: We would need to find a way to enable keyCombo for multiple fields
+  keyCombo: 'ctrl+shift+z',*/
+});

--- a/packages/uikit-workshop/src/scripts/components/panels.js
+++ b/packages/uikit-workshop/src/scripts/components/panels.js
@@ -68,7 +68,9 @@ function init(event) {
   Panels.add({
     id: 'pl-panel-pattern',
     name: window.config.patternExtension.toUpperCase(),
-    default: true,
+    default: !window.config.defaultPatternInfoPanelCode ||
+              window.config.defaultPatternInfoPanelCode ===
+              window.config.patternExtension,
     templateID: 'pl-panel-template-code',
     httpRequest: true,
     httpRequestReplace: fileSuffixPattern,


### PR DESCRIPTION
Closes #1163
Related to #1155 #1156

Summary of changes:
Reverted parts to the previously used placeholders within the `/packages/plugin-tab/src/snippet.js` file, and modified `/packages/plugin-tab/dist/js/@pattern-lab-plugin-tab.js` accordingly by migrating some code to that file.

This would reenable defining one or more filetypes to display within the code panels again.