### PR TITLE
Fix logo image path

### DIFF
--- a/packages/docs/src/_includes/components/logo.njk
+++ b/packages/docs/src/_includes/components/logo.njk
@@ -1,7 +1,7 @@
 
 <h3 class="c-logo">
 	<a href="/" class="c-logo__link" rel="home">
-	    <img class="c-logo__img" src="https://patternlab.io/assets/icon-atom.svg" alt="Pattern Lab">
+	    <img class="c-logo__img" src="https://patternlab.io/images/icon-atom.svg" alt="Pattern Lab">
 
 		<div class="c-logo__body">
 			<span class="c-logo__text">Pattern Lab</span>


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Summary of changes:
- Changed the logo path from `https://patternlab.io/assets/icon-atom.svg` to `https://patternlab.io/images/icon-atom.svg`