### PR TITLE
chore(docs): simple typo

### DIFF
--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -37,7 +37,7 @@ You may want to put some space between the numbers just in case you want to furt
 
 The numbers will not show up when Pattern Lab displays the name of the pattern in the drop-down navigation. They're simply a re-ordering mechanism.
 
-##Re-ordering Pseudo-Patterns
+## Re-ordering Pseudo-Patterns
 
 The rules for re-ordering [pseudo-patterns](/docs/pattern-pseudo-patterns.html) are slightly different than normal patterns. The numbers go **after** the tilde sign (`~`) rather than at the beginning of the file name. For instance:
 


### PR DESCRIPTION
Summary of changes:
Added a missing space in front of the text for that headline.