### PR TITLE
chore(links): prevent redirects both on internal as well as external URLs #1195

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This monorepo contains the core of Pattern Lab / Node and all related engines, UI kits, plugins and utilities. Pattern Lab helps you and your team build thoughtful, pattern-driven user interfaces using atomic design principles.
 
-If you'd like to see what a front-end project built with Pattern Lab looks like, check out this [online demo of Pattern Lab output](http://demo.patternlab.io/).
+If you'd like to see what a front-end project built with Pattern Lab looks like, check out this [online demo of Pattern Lab output](https://demo.patternlab.io/).
 
 [![Build Status](https://travis-ci.org/pattern-lab/patternlab-node.svg?branch=master)](https://travis-ci.org/pattern-lab/patternlab-node)
 ![current release](https://img.shields.io/npm/v/@pattern-lab/core.svg)

--- a/packages/docs/src/_data/navigation.json
+++ b/packages/docs/src/_data/navigation.json
@@ -48,15 +48,15 @@
 	"footerNav": [
 		{
 			"label": "Resources",
-			"url": "/resources"
+			"url": "/resources/"
 		},
 		{
 			"label": "Updates",
-			"url": "/updates"
+			"url": "/updates/"
 		},
 		{
 			"label": "Demos",
-			"url": "/demos"
+			"url": "/demos/"
 		},
 		{
 			"label": "On Github",

--- a/packages/docs/src/_includes/layouts/home.njk
+++ b/packages/docs/src/_includes/layouts/home.njk
@@ -10,21 +10,21 @@
             <li class="c-tile-list__item">
                 {% set styleModifier = 'c-tile--green' %}
                 {% set title = 'Read the docs' %}
-                {% set link = '/docs/installing-pattern-lab' %}
+                {% set link = '/docs/installing-pattern-lab/' %}
                 {% set description = "Learn how to get up and running with Pattern Lab, work with patterns, design with dynamic data, and use Pattern Lab's advanced features." %}
                 {% include "components/tile.njk" %}
             </li>
             <li class="c-tile-list__item">
                 {% set styleModifier = 'c-tile--orange' %}
                 {% set title = 'Demos' %}
-                {% set link = '/demos' %}
+                {% set link = '/demos/' %}
                 {% set description = "Demos of pattern starterkits for your project as well as a gallery of Pattern Lab projects in the wild" %}
                 {% include "components/tile.njk" %}
             </li>
             <li class="c-tile-list__item">
                 {% set styleModifier = 'c-tile--purple' %}
                 {% set title = 'Resources' %}
-                {% set link = '/resources' %}
+                {% set link = '/resources/' %}
                 {% set description = "Links to articles and resources around Pattern Lab and design systems" %}
                 {% include "components/tile.njk" %}
             </li>
@@ -84,7 +84,7 @@
         
         {% set styleModifier = 'c-tile--orange' %}
         {% set title = 'Open source and community driven' %}
-        {% set link = '/support' %}
+        {% set link = '/support/' %}
         {% set description = "Pattern Lab is (and will always be) an open source project. Check out the project on <a href='https://github.com/pattern-lab/patternlab-node'>GitHub</a> and join the <a href='https://gitter.im/pattern-lab/home'>Pattern Lab Gitter community</a> for conversation and support." %}
         {% include "components/tile.njk" %}
 

--- a/packages/docs/src/demos/pattern-lab-two-mustache-demo.md
+++ b/packages/docs/src/demos/pattern-lab-two-mustache-demo.md
@@ -1,7 +1,7 @@
 ---
 title: Pattern Lab 2 Mustache Demo
 description: Pattern Lab 1 projects should work with minimal changes in Pattern Lab 2.
-url: http://demo.patternlab.io/
+url: https://demo.patternlab.io/
 category: starterkit
 tags:
   - demo-PL2

--- a/packages/docs/src/docs/advanced-integration-with-grunt.md
+++ b/packages/docs/src/docs/advanced-integration-with-grunt.md
@@ -38,4 +38,4 @@ You should also be using `grunt-contrib-watch` to monitor changes to Pattern Lab
 
 You might be able to use `livereload` as well but that hasn't been tested by us yet.
 
-For more information, check out [this post about using Pattern Lab with Grunt](http://bradfrost.com/blog/post/using-grunt-with-pattern-lab/).
+For more information, check out [this post about using Pattern Lab with Grunt](https://bradfrost.com/blog/post/using-grunt-with-pattern-lab/).

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -8,7 +8,7 @@ title: Resources
 - [Styleguides.io](http://styleguides.io)
 - [Atomic Design by Brad Frost](http://atomicdesign.bradfrost.com)
 - [Atomic design article](http://bradfrost.com/blog/post/atomic-web-design/)
-- [A new link](http://google.com)
+- [A new link](https://www.google.com/)
 
 ## Pattern Lab Examples
 

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -12,7 +12,7 @@ title: Resources
 
 ## Pattern Lab Examples
 
-- [Pattern Lab Demo](http://demo.patternlab.io/)
+- [Pattern Lab Demo](https://demo.patternlab.io/)
 - [Frost Finery](http://patterns.frostfinery.com)
 - [Pittsburgh Food Bank](http://foodbank.bradfrostweb.com/patternlab/v10/)
 - [brianmuenzenmeyer.com](http://www.brianmuenzenmeyer.com/patternlab/public/)

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -7,7 +7,7 @@ title: Resources
 
 - [Styleguides.io](http://styleguides.io)
 - [Atomic Design by Brad Frost](http://atomicdesign.bradfrost.com)
-- [Atomic design article](http://bradfrost.com/blog/post/atomic-web-design/)
+- [Atomic design article](https://bradfrost.com/blog/post/atomic-web-design/)
 - [A new link](https://www.google.com/)
 
 ## Pattern Lab Examples

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -6,7 +6,7 @@ title: Resources
 ## Style guides and atomic design
 
 - [Styleguides.io](http://styleguides.io)
-- [Atomic Design by Brad Frost](http://atomicdesign.bradfrost.com)
+- [Atomic Design by Brad Frost](https://atomicdesign.bradfrost.com/)
 - [Atomic design article](https://bradfrost.com/blog/post/atomic-web-design/)
 - [A new link](https://www.google.com/)
 
@@ -29,8 +29,8 @@ title: Resources
 
 ## Podcasts
 
-- [Dave Olsen talking Pattern Lab 2 on Non-Breaking Space Podcast](http://goodstuff.fm/nbsp/86)
-- [Brian Muenzenmeyer talking Pattern Lab 2 on the MS DEV SHOW Podcast](http://msdevshow.com/2015/12/pattern-lab-with-brian-muenzenmeyer/)
+- [Dave Olsen talking Pattern Lab 2 on Non-Breaking Space Podcast](https://goodstuff.fm/nbsp/86)
+- [Brian Muenzenmeyer talking Pattern Lab 2 on the MS DEV SHOW Podcast](https://msdevshow.com/2015/12/pattern-lab-with-brian-muenzenmeyer/)
 
 ## Presentations
 

--- a/packages/edition-node-gulp/README.md
+++ b/packages/edition-node-gulp/README.md
@@ -7,7 +7,7 @@
 
 The Gulp wrapper around [Pattern Lab Node Core](https://github.com/pattern-lab/patternlab-node/tree/master/packages/core)), the default PatternEngine, and supporting frontend assets.
 
-[Online Demo of Pattern Lab Output](http://demo.patternlab.io/)
+[Online Demo of Pattern Lab Output](https://demo.patternlab.io/)
 
 ## Packaged Components
 

--- a/packages/edition-node/README.md
+++ b/packages/edition-node/README.md
@@ -7,7 +7,7 @@
 
 The pure wrapper around [Pattern Lab Node Core](https://github.com/pattern-lab/patternlab-node/tree/master/packages/core), the default pattern engine, and supporting frontend assets.
 
-[Online Demo of Pattern Lab Output](http://demo.patternlab.io/)
+[Online Demo of Pattern Lab Output](https://demo.patternlab.io/)
 
 ## Packaged Components
 


### PR DESCRIPTION
Some links are missing a trailing slash, and that for causing a redirect. Adding the trailing slash would speed up browsing.
Additionally linking to the correct (HTTPS version) of the pages would provide an additional aspect of "security".

Closes #1195

Summary of changes:
source (partly): https://validator.w3.org/checklink?uri=https%3A%2F%2Fpatternlab.io%2F&hide_type=all&recursive=on&depth=&check=Check