### PR TITLE
fix(docs): google lighthouse error - bg and text contrast ratio #1197

### DIFF
--- a/packages/docs/src/scss/abstracts/_variables.scss
+++ b/packages/docs/src/scss/abstracts/_variables.scss
@@ -48,7 +48,7 @@ $color-brand-green: #7ec699;
 $color-brand-green-dark: #376548;
 $color-brand-green-light: #f4fdf6;
 $color-brand-orange: #eeb31b;
-$color-brand-orange-dark: #966d04;
+$color-brand-orange-dark: #946900;
 $color-brand-orange-light: #fef8ea;
 
 /**


### PR DESCRIPTION
Background and foreground colors do not have a sufficient contrast ratio

Closes #1197

Summary of changes:
Slightly modifying the orange color code, that is only being used on the tiles pattern on the homepage.