### PR TITLE
Fix broken "open in new tab" link in UIKit 

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
@@ -523,6 +523,10 @@ class IFrame extends BaseLitComponent {
           addressReplacement
         );
 
+        const currentUrl = urlHandler.getFileName(currentPattern);
+        if (currentUrl) {
+          store.dispatch(updateCurrentUrl(currentUrl));
+        }
         store.dispatch(updateCurrentPattern(currentPattern));
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
Just noticed this was broken while reviewing a separate PR... this PR should fix the "Open In New Tab" link in Pattern Lab's context menu so it now opens the correct HTML file vs a broken "undefined" page. 

**Before (Broken)**
![CleanShot 2020-05-09 at 14 20 23](https://user-images.githubusercontent.com/1617209/81481775-6fb4da00-9200-11ea-8ca3-6e876048489c.gif)

**After (Working)**
![CleanShot 2020-05-09 at 14 21 01](https://user-images.githubusercontent.com/1617209/81481789-7ba09c00-9200-11ea-93e1-8280ad4e9d48.gif)
