### PR TITLE
fix: update UIKit link pointing to Pattern Lab Docs

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
@@ -164,7 +164,7 @@ class ToolsMenu extends BaseLitComponent {
           ${!this.ishControlsHide['tools-docs']
             ? html`
                 <li class="pl-c-tools__item">
-                  <pl-button href="https://patternlab.io/docs/" target="_blank">
+                  <pl-button href="https://patternlab.io" target="_blank">
                     Pattern Lab Docs
                     <pl-icon name="help" slot="after"></pl-icon>
                   </pl-button>


### PR DESCRIPTION
Fixes the "Pattern Lab Docs" link in PL's menu so it doesn't hit a 404.