### PR TITLE
docs(attributes): modified related to implementation

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -275,7 +275,7 @@ Introduced in Pattern Lab Node v3, UIKits are a new term in the Pattern Lab [Eco
 
 - `enabled`: quickly turn on or off the building of this UIKit
 - `excludedPatternStates`: tell Pattern Lab not to include patterns with these states in this UIKit's output
-- `excludedPatternTags`: tell Pattern Lab not to include patterns with these tags in this UIKit's output
+- `excludedTags`: tell Pattern Lab not to include patterns with these tags in this UIKit's output
 
 Important details:
 

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -276,7 +276,6 @@ Introduced in Pattern Lab Node v3, UIKits are a new term in the Pattern Lab [Eco
 - `enabled`: quickly turn on or off the building of this UIKit
 - `excludedPatternStates`: tell Pattern Lab not to include patterns with these states in this UIKit's output
 - `excludedPatternTags`: tell Pattern Lab not to include patterns with these tags in this UIKit's output
-  - [currently not supported](https://github.com/pattern-lab/patternlab-node/issues/844)
 
 Important details:
 

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -46,5 +46,5 @@ We'd name our documentation file:
 
 ## Adding More Attributes to the Front Matter
 
-A future update of Pattern Lab will support more front matter attributes including: state, order, hidden, links and tags.
+A future update of Pattern Lab will support more front matter attributes including: order, hidden, links and tags.
 It will also support adding custom attributes that could be utilized by plugins. For example, GitHub issues related to patterns.

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -18,7 +18,14 @@ title: Title for my pattern
 This is a *Markdown* description of my pattern.
 ```
 
-The `title` attribute is used in Pattern Lab's navigation as well as in the styleguide views. The `description` is used in the styleguide views.
+Attributes overview:
+* The `title` attribute is used in Pattern Lab's navigation as well as in the styleguide views. Format: `string`
+* Pattern `tags` has to be an array, like `tags: [new, relaunch, dev]`
+* [Pattern `states`](/docs/using-pattern-states/) are defined like `state: incomplete` and [provide a simple visual indication](/docs/using-pattern-states/)
+
+Both `tags` and `states` could be used for [not including patterns in a UIKit specific build](/docs/editing-the-configuration-options/#heading-uikits).
+
+The `description` is used in the styleguide views.
 
 Pattern documentation needs to have a `.md` file extension and match the name of the pattern it's documenting. For example, to document the following pattern:
 

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -46,5 +46,5 @@ We'd name our documentation file:
 
 ## Adding More Attributes to the Front Matter
 
-A future update of Pattern Lab will support more front matter attributes including: order, hidden and links.
+A future update of Pattern Lab will support more front matter attributes including: excludeFromStyleguide, order, hidden and links.
 It will also support adding custom attributes that could be utilized by plugins. For example, GitHub issues related to patterns.

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -46,5 +46,5 @@ We'd name our documentation file:
 
 ## Adding More Attributes to the Front Matter
 
-A future update of Pattern Lab will support more front matter attributes including: order, hidden, links and tags.
+A future update of Pattern Lab will support more front matter attributes including: order, hidden and links.
 It will also support adding custom attributes that could be utilized by plugins. For example, GitHub issues related to patterns.


### PR DESCRIPTION
Closes #1207

Summary of changes:
- Modified the docs according to the implementations regarding both `state` and `tags`.
- Additionally corrected from `excludedPatternTags` to `excludedTags`.
- Added `excludeFromStyleguide` to the list as mentioned in #1209