### PR TITLE
fix(patternstate): added css color for pattern state "inprogress" #1216

### DIFF
--- a/packages/uikit-workshop/src/sass/scss/01-abstracts/_variables.scss
+++ b/packages/uikit-workshop/src/sass/scss/01-abstracts/_variables.scss
@@ -24,6 +24,7 @@ $pl-color-trans-white-25: rgba(255, 255, 255, 0.25);
 $pl-color-state-info: #02a4d5;
 $pl-color-state-complete: #03790f;
 $pl-color-state-inreview: #c7a118;
+$pl-color-state-inprogress: #b00b02;
 $pl-color-state-deprecated: #b00b02;
 
 // Font Family

--- a/packages/uikit-workshop/src/sass/scss/04-components/_pattern-states.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_pattern-states.scss
@@ -22,6 +22,10 @@
     background-color: $pl-color-state-inreview;
   }
 
+  &--inprogress {
+    background-color: $pl-color-state-inprogress;
+  }
+
   &--deprecated {
     background-color: $pl-color-state-deprecated;
   }


### PR DESCRIPTION
Closes #1216

Summary of changes:
Added patterns states `inprogress` color definition to the UI Kits SCSS file, according to request issue #1216 and chosen the color according to the specs: https://patternlab.io/docs/using-pattern-states/#heading-the-default-pattern-states