### PR TITLE
fix(docs): fixed css code for custom patternstates color

### DIFF
--- a/packages/docs/src/docs/pattern-states.md
+++ b/packages/docs/src/docs/pattern-states.md
@@ -45,8 +45,8 @@ The three default states included with Pattern Lab might not be enough for every
 You can use the following as your CSS template for new pattern states:
 
 ```css
-{% raw %}.newpatternstate:before {
-    color: #B10DC9 !important;
+{% raw %}.pl-c-pattern-state--newpatternstate {
+    background-color: #B10DC9;
 }{% endraw %}
 ```
 


### PR DESCRIPTION
_didn't open another issue for this quick docs fix._

Summary of changes:
Corrected the specs regarding new / custom states color, aligned with the newer syntax in file https://github.com/pattern-lab/patternlab-node/blob/dev/packages/uikit-workshop/src/sass/scss/04-components/_pattern-states.scss

Recognized this out of fix made that was the issue reported by #1216

btw. what about the specs in the folder `/packages/docs/php-docs/pattern-states.md`, do you (still) change all of those accordingly ?