### PR TITLE
improvement(core): added npmignore #1186

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,2 @@
+test
+.nyc_output


### PR DESCRIPTION
Closes #1186

Summary of changes:
Added `.npmignore` file for the folders described in the ticket #1186: `.nyc_output` and `test`

In case that any further files or folders are necessary, these should get added to that file as well.