### PR TITLE
fix(patternflyouts): preventing horizontal scrollbar in Edge 18 #1124

### DIFF
--- a/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.scss
+++ b/packages/uikit-workshop/src/scripts/components/pl-nav/pl-nav.scss
@@ -586,7 +586,7 @@ pl-nav {
   opacity: 1;
 
   .pl-c-body--theme-horizontal & {
-    overflow: auto;
+    overflow-y: auto;
   }
 
   @media all and (min-width: $pl-bp-med) {


### PR DESCRIPTION
Closes #1124

Summary of changes:
Replaced `overflow` with `overflow` with `overflow-y` as we only need a vertical overflow and would like to prevent potential horizontal scrollbars.