### PR TITLE
fix(resetcss): selector in uikit-workshop #1109

### DIFF
--- a/packages/uikit-workshop/src/sass/scss/02-base/_reset.scss
+++ b/packages/uikit-workshop/src/sass/scss/02-base/_reset.scss
@@ -16,7 +16,7 @@
   box-sizing: border-box;
 }
 
-button {
+button[class|="pl-c"] {
   font-size: inherit;
   background-color: transparent;
 }


### PR DESCRIPTION
Closes #1109

Summary of changes:
Optimized regarding unnamespaced button style.