### PR TITLE
Fix unhandled promise rejection on server.open

### DIFF
--- a/packages/live-server/index.js
+++ b/packages/live-server/index.js
@@ -368,9 +368,17 @@ LiveServer.start = function(options) {
     // Launch browser
     if (openPath !== null)
       if (typeof openPath === 'object') {
-        openPath.forEach(p => open(openURL + p, { app: browser }));
+        openPath.forEach(p =>
+          open(openURL + p, { app: browser }).catch(() =>
+            console.log(
+              'Warning: Could not open pattern lab in default browser.'
+            )
+          )
+        );
       } else {
-        open(openURL + openPath, { app: browser });
+        open(openURL + openPath, { app: browser }).catch(() =>
+          console.log('Warning: Could not open pattern lab in default browser.')
+        );
       }
   });
 


### PR DESCRIPTION
Closes #1231 

Summary of changes:

In a docker container with no browser installed, an unhandled promise rejection occured when `pl:serve` tried to open pattern lab in a browser.
