### PR TITLE
Fix live-server injects code to SVGs

### DIFF
--- a/packages/live-server/index.js
+++ b/packages/live-server/index.js
@@ -50,7 +50,6 @@ function staticServer(root) {
     const hasNoOrigin = !req.headers.origin;
     const injectCandidates = [
       new RegExp('</body>', 'i'),
-      new RegExp('</svg>', 'g'),
       new RegExp('</head>', 'i'),
     ];
 


### PR DESCRIPTION
Closes #1019 

Summary of changes:

Since we never render a page without head or body it makes no sence to inject code to SVGs and it also could lead to some unexpected behavior.