### PR TITLE
load_plugin and is_plugin is not used anymore in the code base

### DIFF
--- a/packages/core/src/lib/plugin_manager.js
+++ b/packages/core/src/lib/plugin_manager.js
@@ -1,36 +1,7 @@
 'use strict';
 
 const plugin_manager = function() {
-  const path = require('path');
   const logger = require('./log');
-
-  const pluginMatcher = /^plugin-(.*)$/;
-
-  /**
-   * Loads a plugin
-   *
-   * @param modulePath {string} the path to the plugin
-   * @return {object} the loaded plugin
-   */
-  function loadPlugin(modulePath) {
-    return require(modulePath);
-  }
-
-  /**
-   * Given a path: return the plugin name if the path points to a valid plugin
-   * module directory, or false if it doesn't.
-   * @param filePath
-   * @returns Plugin name if exists or FALSE
-   */
-  function isPlugin(filePath) {
-    const baseName = path.basename(filePath);
-    const pluginMatch = baseName.match(pluginMatcher);
-
-    if (pluginMatch) {
-      return pluginMatch[1];
-    }
-    return false;
-  }
 
   /**
    * Looks for installed plugins, loads them, and invokes them
@@ -41,7 +12,7 @@ const plugin_manager = function() {
     foundPlugins.forEach(plugin => {
       logger.info(`Found plugin: ${plugin}`);
       logger.info(`Attempting to load and initialize plugin.`);
-      const pluginModule = loadPlugin(plugin);
+      const pluginModule = require(plugin);
       pluginModule(patternlab);
     });
   }
@@ -60,12 +31,6 @@ const plugin_manager = function() {
   return {
     intialize_plugins: patternlab => {
       initializePlugins(patternlab);
-    },
-    load_plugin: modulePath => {
-      return loadPlugin(modulePath);
-    },
-    is_plugin: filePath => {
-      return isPlugin(filePath);
     },
     raiseEvent: async (patternlab, eventName, ...args) => {
       await raiseEvent(patternlab, eventName, args);


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Summary of changes:
* `load_plugin` and `is_plugin` on `plugin_manager` is not used anymore in the codebase. Cleaning up.