### PR TITLE
Enable doc tables and fix frontmatter bug

### DIFF
--- a/packages/core/src/lib/markdown_parser.js
+++ b/packages/core/src/lib/markdown_parser.js
@@ -15,7 +15,7 @@ const markdown_parser = function() {
     try {
       // for each block process the yaml frontmatter and markdown
       // even if the pattern only has pattern data without further documentation
-      const frontmatterRE = /---\r?\n{1}([\s\S]*)---([\s\S]*)+/gm;
+      const frontmatterRE = /---\r?\n{1}([\s\S]*)^---([\s\S]*)+/gm;
       const chunks = frontmatterRE.exec(block);
 
       if (chunks) {

--- a/packages/uikit-workshop/src/sass/scss/04-components/_text-passage.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_text-passage.scss
@@ -136,4 +136,29 @@
   li {
     margin-bottom: 0.5rem;
   }
+
+  table {
+    width: 100%;
+    max-width: 100%;
+    border-collapse: collapse;
+    overflow-x: auto;
+    margin: 0.75rem auto;
+  }
+
+  tr:nth-of-type(odd) {
+    background: $pl-color-gray-07;
+  }
+
+  th {
+    background: $pl-color-gray-13;
+    color: black;
+    font-weight: bold;
+  }
+
+  td,
+  th {
+    padding: 10px;
+    border: 1px solid $pl-color-gray-20;
+    text-align: left;
+  }
 }


### PR DESCRIPTION
Closes #1242 
Closes #1243

Summary of changes:

Fixes the bug that tables could not render in pattern documentation if frontmatter were available.

Also, adding some styling for tables, since they got added but where not styled in any way in the pattern documentation.