### PR TITLE
chore(repo): retires Brian from active involvement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ This ensures that any changes you've made will still result in a clean and funct
 
 ## Guidelines
 
-* _ALWAYS_ submit pull requests against the [dev branch](https://github.com/pattern-lab/patternlab-node/tree/dev). If this does not occur, I will first, try to redirect you gently, second, attempt to redirect the target branch myself, thirdly, port over your contribution manually if time allows, and/or lastly, close your pull request. If you have a major feature to stabilize over time, talk to @bmuenzenmeyer via an issue about making a dedicated `feature-branch`
+* _ALWAYS_ submit pull requests against the [dev branch](https://github.com/pattern-lab/patternlab-node/tree/dev). If this does not occur, we will first, try to redirect you gently, second, attempt to redirect the target branch myself, thirdly, port over your contribution manually if time allows, and/or lastly, close your pull request. If you have a major feature to stabilize over time, ping @pattern-lab/trusted-committers via an issue about making a dedicated `feature-branch`
 * Keep your pull requests concise and limited to **ONE** substantive change at a time. This makes reviewing and testing so much easier.
 * If it takes you considerable time to finish your work, submit a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). This is Github's way to indicate work in progress but allows for feedback.
 * Commits should reference the issue you are adressing. For any Pull Request that you send, use the template provided.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-patreon: patternlab

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at brian.muenzenmeyer@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team by opening an issue. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,10 @@ Core, and Editions, are part of the [Pattern Lab Ecosystem](https://patternlab.i
 
 ## Support for Pattern Lab
 
-Pattern Lab / Node wouldn't be what it is today without the support of the community. It will always be free and open source. Continued development is made possible in part from the support of [these wonderful project supporters](https://github.com/pattern-lab/patternlab-node/wiki/Thanks). If you want to learn more about supporting the project, visit the [Pattern Lab / Node Patreon page](https://www.patreon.com/patternlab).
+Pattern Lab / Node wouldn't be what it is today without the support of the community. It will always be free and open source. Continued development is made possible in part from the support of [contributors](https://github.com/pattern-lab/patternlab-node/graphs/contributors).
 
-**:100: Thanks for support from the following:**
+Thanks to [Netlify](https://www.netlify.com/) for build tooling and hosting. 
 
-* **[Brad Frost](http://bradfrost.com/)**
-* Jan Ditze
-* [Marcos Peebles](https://twitter.com/marcospeebles)
-* [Maximilian Franzke](https://twitter.com/maedmaex)
-* [Susan Simkins](https://twitter.com/susanmsimkins)
 
 ## Contributing
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -102,7 +102,6 @@ Please read the [contribution guidelines](https://github.com/pattern-lab/pattern
 
 ## Core Team
 
-* [@bmuenzenmeyer](https://github.com/bmuenzenmeyer) - Lead Maintainer
 * [@geoffp](https://github.com/geoffp) - Core Contributor
 * [@raphaelokon](https://github.com/raphaelokon) - CLI Contributor
 * [@tburny](https://github.com/tburny) - Core Contributor


### PR DESCRIPTION
I need to step away from PL. I am very happy to see it in good hands and active.

This PR removes active references to me, but retains some of the licensing and author fields. If that needs to be normalized, do so.

I've deactivated my patreon account. It was the main source of funding for the open source netlify team we pay for each month.