### PR TITLE
Remove last traces of `installplugin` from `core` package

### DIFF
--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -19,13 +19,13 @@ const patternlab = require('@pattern-lab/core')(config);
 Build thoughtful, pattern-driven user interfaces using atomic design principles.
 Many of these functions are exposed to users within [Editions](https://github.com/pattern-lab/patternlab-node#editions), but [direct consumption](https://github.com/pattern-lab/patternlab-node#direct-consumption) is also encouraged.
 
-**Kind**: global namespace  
+**Kind**: global namespace
 **See**
 
 - [patternlab.io](patternlab.io) for more documentation.
 - [https://github.com/pattern-lab/patternlab-node](https://github.com/pattern-lab/patternlab-node) for code, issues, and releases
 
-**License**: MIT  
+**License**: MIT
 
 * [`patternlab`](#patternlab) : <code>object</code>
     * _instance_
@@ -33,7 +33,6 @@ Many of these functions are exposed to users within [Editions](https://github.co
         * [`.build`](#patternlab+build) ⇒ <code>Promise</code>
         * [`.getDefaultConfig`](#patternlab+getDefaultConfig) ⇒ <code>object</code>
         * [`.getSupportedTemplateExtensions`](#patternlab+getSupportedTemplateExtensions) ⇒ <code>Array.&lt;string&gt;</code>
-        * [`.installplugin`](#patternlab+installplugin) ⇒ <code>void</code>
         * [`.liststarterkits`](#patternlab+liststarterkits) ⇒ <code>Promise</code>
         * [`.loadstarterkit`](#patternlab+loadstarterkit) ⇒ <code>void</code>
         * [`.patternsonly`](#patternlab+patternsonly) ⇒ <code>Promise</code>
@@ -51,17 +50,17 @@ Many of these functions are exposed to users within [Editions](https://github.co
 ### `patternlab.version` ⇒ <code>string</code>
 Returns current version
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>string</code> - current patternlab-node version as defined in `package.json`, as string  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>string</code> - current patternlab-node version as defined in `package.json`, as string
 <a name="patternlab+build"></a>
 
 ### `patternlab.build` ⇒ <code>Promise</code>
 Builds patterns, copies assets, and constructs user interface
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>Promise</code> - a promise fulfilled when build is complete  
-**Emits**: <code>event:PATTERNLAB_BUILD_START</code>, <code>event:PATTERNLAB_BUILD_END</code>  
-**See**: [all events](./events.md)  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>Promise</code> - a promise fulfilled when build is complete
+**Emits**: <code>event:PATTERNLAB_BUILD_START</code>, <code>event:PATTERNLAB_BUILD_END</code>
+**See**: [all events](./events.md)
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -75,39 +74,29 @@ Builds patterns, copies assets, and constructs user interface
 ### `patternlab.getDefaultConfig` ⇒ <code>object</code>
 Returns the standardized default config used to run Pattern Lab. This method can be called statically or after instantiation.
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>object</code> - Returns the object representation of the `patternlab-config.json`  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>object</code> - Returns the object representation of the `patternlab-config.json`
 <a name="patternlab+getSupportedTemplateExtensions"></a>
 
 ### `patternlab.getSupportedTemplateExtensions` ⇒ <code>Array.&lt;string&gt;</code>
 Returns all file extensions supported by installed PatternEngines
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>Array.&lt;string&gt;</code> - all supported file extensions  
-<a name="patternlab+installplugin"></a>
-
-### `patternlab.installplugin` ⇒ <code>void</code>
-Installs plugin already available via `node_modules/`
-
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| pluginName | <code>string</code> | name of plugin |
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>Array.&lt;string&gt;</code> - all supported file extensions
 
 <a name="patternlab+liststarterkits"></a>
 
 ### `patternlab.liststarterkits` ⇒ <code>Promise</code>
 Fetches starterkit repositories from pattern-lab github org that contain 'starterkit' in their name
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>Promise</code> - Returns an Array<{name,url}> for the starterkit repos  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>Promise</code> - Returns an Array<{name,url}> for the starterkit repos
 <a name="patternlab+loadstarterkit"></a>
 
 ### `patternlab.loadstarterkit` ⇒ <code>void</code>
 Loads starterkit already available via `node_modules/`
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -119,8 +108,8 @@ Loads starterkit already available via `node_modules/`
 ### `patternlab.patternsonly` ⇒ <code>Promise</code>
 Builds patterns only, leaving existing user interface files intact
 
-**Kind**: instance property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>Promise</code> - a promise fulfilled when build is complete  
+**Kind**: instance property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>Promise</code> - a promise fulfilled when build is complete
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -133,21 +122,21 @@ Builds patterns only, leaving existing user interface files intact
 ### `patternlab.getDefaultConfig` ⇒ <code>object</code>
 Static method that returns the standardized default config used to run Pattern Lab. This method can be called statically or after instantiation.
 
-**Kind**: static property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>object</code> - Returns the object representation of the `patternlab-config.json`  
+**Kind**: static property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>object</code> - Returns the object representation of the `patternlab-config.json`
 <a name="patternlab.getVersion"></a>
 
 ### `patternlab.getVersion` ⇒ <code>string</code>
 Static method that returns current version
 
-**Kind**: static property of [<code>patternlab</code>](#patternlab)  
-**Returns**: <code>string</code> - current @pattern-lab/core version as defined in `package.json`  
+**Kind**: static property of [<code>patternlab</code>](#patternlab)
+**Returns**: <code>string</code> - current @pattern-lab/core version as defined in `package.json`
 <a name="patternlab.server"></a>
 
 ### `patternlab.server` : <code>object</code>
 Server module
 
-**Kind**: static property of [<code>patternlab</code>](#patternlab)  
+**Kind**: static property of [<code>patternlab</code>](#patternlab)
 
 * [`.server`](#patternlab.server) : <code>object</code>
     * [`.serve(options)`](#patternlab.server.serve) ⇒ <code>Promise</code>
@@ -159,8 +148,8 @@ Server module
 #### `server.serve(options)` ⇒ <code>Promise</code>
 Build patterns, copies assets, and constructs user interface. Watches configured `source/` directories, and serves all output locally
 
-**Kind**: static method of [<code>server</code>](#patternlab.server)  
-**Returns**: <code>Promise</code> - a promise fulfilled when build is complete  
+**Kind**: static method of [<code>server</code>](#patternlab.server)
+**Returns**: <code>Promise</code> - a promise fulfilled when build is complete
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -174,19 +163,19 @@ Build patterns, copies assets, and constructs user interface. Watches configured
 #### `server.reload()` ⇒ <code>Promise</code>
 Reloads any active live-server instances
 
-**Kind**: static method of [<code>server</code>](#patternlab.server)  
-**Returns**: <code>Promise</code> - a promise fulfilled when operation is complete  
+**Kind**: static method of [<code>server</code>](#patternlab.server)
+**Returns**: <code>Promise</code> - a promise fulfilled when operation is complete
 <a name="patternlab.server.refreshCSS"></a>
 
 #### `server.refreshCSS()` ⇒ <code>Promise</code>
 Reloads CSS on any active live-server instances
 
-**Kind**: static method of [<code>server</code>](#patternlab.server)  
-**Returns**: <code>Promise</code> - a promise fulfilled when operation is complete  
+**Kind**: static method of [<code>server</code>](#patternlab.server)
+**Returns**: <code>Promise</code> - a promise fulfilled when operation is complete
 <a name="patternlab.events"></a>
 
 ### `patternlab.events` : <code>EventEmitter</code>
-**Kind**: static property of [<code>patternlab</code>](#patternlab)  
+**Kind**: static property of [<code>patternlab</code>](#patternlab)
 **See**
 
 - [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -205,21 +205,6 @@ const patternlab_module = function(config) {
     },
 
     /**
-     * Installs plugin already available as a package dependency
-     *
-     * @memberof patternlab
-     * @name installplugin
-     * @instance
-     * @param {string} pluginName name of plugin
-     * @returns {void}
-     */
-    installplugin: function(pluginName) {
-      const plugin_manager = new pm();
-
-      plugin_manager.install_plugin(pluginName);
-    },
-
-    /**
      * Fetches starterkit repositories from pattern-lab github org that contain 'starterkit' in their name
      *
      * @memberof patternlab

--- a/packages/development-edition-engine-react/gulpfile.js
+++ b/packages/development-edition-engine-react/gulpfile.js
@@ -65,8 +65,4 @@ gulp.task('patternlab:serve', function() {
   });
 });
 
-gulp.task('patternlab:installplugin', function() {
-  patternlab.installplugin(argv.plugin);
-});
-
 gulp.task('default', ['patternlab:help']);

--- a/packages/edition-node-gulp/gulpfile.js
+++ b/packages/edition-node-gulp/gulpfile.js
@@ -62,8 +62,4 @@ gulp.task('patternlab:serve', function() {
   });
 });
 
-gulp.task('patternlab:installplugin', function() {
-  patternlab.installplugin(argv.plugin);
-});
-
 gulp.task('default', ['patternlab:help']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,6 +1988,14 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@pattern-lab/starterkit-handlebars-vanilla@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pattern-lab/starterkit-handlebars-vanilla/-/starterkit-handlebars-vanilla-1.4.0.tgz#aac144d0c21d40226f90ac5ce1b5d8505dddf330"
+  integrity sha512-inkcRhpYfm0q58zEQ9Gx2S+iVu+prAtRgqLw5Opd0MYC74NMcqN9XrcbJva4NfLn1tgx9dkA3Xmtg0IxiTHnAw==
+  dependencies:
+    node-sass "^4.12.0"
+    node-sass-glob-importer "^5.3.2"
+
 "@pattern-lab/starterkit-mustache-base@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@pattern-lab/starterkit-mustache-base/-/starterkit-mustache-base-3.0.3.tgz#8ce9bc8e0d2254ee970a09c4bdc76d4f6131c91d"
@@ -12550,6 +12558,13 @@ node-releases@^1.1.38:
   dependencies:
     semver "^6.3.0"
 
+node-sass-glob-importer@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/node-sass-glob-importer/-/node-sass-glob-importer-5.3.2.tgz#465581e46027c0e9520e6d87f7e6eda858a14acb"
+  integrity sha512-QTX7KPsISgp55REV6pMH703nzHfWCOEYEQC0cDyTRo7XO6WDvyC0OAzekuQ4gs505IZcxv9KxZ3uPJ5s5H9D3g==
+  dependencies:
+    node-sass-magic-importer "^5.3.2"
+
 node-sass-magic-importer@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/node-sass-magic-importer/-/node-sass-magic-importer-5.3.2.tgz#2f2248bb2e5cdb275ba34102ebf995edadf99175"
@@ -12572,7 +12587,7 @@ node-sass-selector-importer@^5.2.0:
     node-sass-magic-importer "^5.3.2"
     postcss-scss "^2.0.0"
 
-node-sass@^4.14.1:
+node-sass@^4.12.0, node-sass@^4.14.1:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #872

`core/src/lib/plugin_manager.js`
- [x] `installPlugin`
- [x] `enablePlugin`
- [x] `disablePlugin`
The above functions were already removed in https://github.com/pattern-lab/patternlab-node/commit/5a588240400870203c682d5071cd32f6dff9f94d#diff-8ca6325b129e4d3d6f16071bdc09970b (17 Jul 2018)

Summary of changes:

`core/src/index.js`
- [x]  `installplugin`

`edition-node-gulp/gulpfile.js`
- [x] `patternlab:installplugin`

Removed these entries as they couldn't have worked in the past 2 years anyway. The fact that this went unnoticed for so long means nobody used it.