### PR TITLE
chore(repo): retires Raphael from active involvement

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,9 +7,6 @@
 # review when someone opens a pull request.
 @pattern-lab/trusted-committers
 
-# CLI owner
-/packages/cli @raphaelokon
-
 # uikit-workshop owner
 /packages/uikit-workshop @sghoweri
 

--- a/packages/cli/license
+++ b/packages/cli/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Raphael Okon
+Copyright Patternlab contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
     "patternlab": "bin/patternlab.js"
   },
   "author": {
-    "name": "Raphael Okon"
+    "name": "Patternlab contributors"
   },
   "dependencies": {
     "@pattern-lab/core": "^5.13.1",

--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -139,4 +139,4 @@ Installs Pattern Lab related modules like starterkits or plugins
     $ patternlab build --config <path/to/patternlab-config> # Builds Pattern Lab from different project directory
 ```
 ## License
-MIT © [Raphael Okon](https://github.com/raphaelokon)
+MIT © [Patternlab contributors](https://github.com/pattern-lab/patternlab-node/blob/master/CODEOWNERS)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -103,7 +103,6 @@ Please read the [contribution guidelines](https://github.com/pattern-lab/pattern
 ## Core Team
 
 * [@geoffp](https://github.com/geoffp) - Core Contributor
-* [@raphaelokon](https://github.com/raphaelokon) - CLI Contributor
 * [@tburny](https://github.com/tburny) - Core Contributor
 
 ## Community

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,9 +56,6 @@
       "name": "Geoff Pursell"
     },
     {
-      "name": "Raphael Okon"
-    },
-    {
       "name": "tburny"
     }
   ],


### PR DESCRIPTION
Hi there. It has been a long time :-) 

I need to step away from `patternlab` and the `patternlab-cli`.

This PR includes the following changes:
- It normalizes some licensing in the `patternlab-cli` package.
- It normalizes the `patternlab-cli` author field.
- It removes any references to me.

It was a great time to work with @bmuenzenmeyer et al. on this—and it is great to see Patternlab being actively developed and please all keep up the great work. 

All the best,
Raph