### PR TITLE
docs(configuration): entry for preventing filetypes from being copied

### DIFF
--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -52,7 +52,7 @@ Note how some sets of files even extend into the "vendor" `./node_modules/` dire
 
 ## Preventing specific filetypes form being copied
 
-If you'd like to prevent specific filetypes from being copied from your `source` to your `public` folder like e.g. CSS preprocessor source files (`.scss`), you could specify those within an array of your patternlab config:
+If you'd like to prevent specific filetypes from being copied from your `source` to your `public` folder like e.g. CSS preprocessor source files (`.scss`), you could specify those within an array of your pattern lab config:
 ``` json
 {
   "transformedAssetTypes": ["scss"],

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -50,7 +50,7 @@ Pattern Lab has a configuration object which allows users to separate source pat
 
 Note how some sets of files even extend into the "vendor" `./node_modules/` directory. Relative paths are the default but absolute paths are supported also. You may also use these paths within the Grunt or Gulp taskfiles by referring to the `paths()` function.
 
-## Preventing specific filetypes form being copied
+## Preventing specific filetypes from being copied
 
 If you'd like to prevent specific filetypes from being copied from your `source` to your `public` folder like e.g. CSS preprocessor source files (`.scss`), you could specify those within an array of your pattern lab config:
 ``` json

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -50,6 +50,15 @@ Pattern Lab has a configuration object which allows users to separate source pat
 
 Note how some sets of files even extend into the "vendor" `./node_modules/` directory. Relative paths are the default but absolute paths are supported also. You may also use these paths within the Grunt or Gulp taskfiles by referring to the `paths()` function.
 
+## Preventing specific filetypes form being copied
+
+If you'd like to prevent specific filetypes from being copied from your `source` to your `public` folder like e.g. CSS preprocessor source files (`.scss`), you could specify those within an array of your patternlab config:
+``` json
+{
+  "transformedAssetTypes": ["scss"],
+}
+```
+
 ## Adding Assets to the Pattern Header &amp; Footer
 
 Static assets like Javascript and CSS **are not** added automagically to your patterns. You need to add them manually to the [shared pattern header and footer](/docs/modifying-the-pattern-header-and-footer/).


### PR DESCRIPTION
Closes #1261

Summary of changes:
Added documentation regarding the configuration option to prevent filetypes from being copied from `source` to `public`