### PR TITLE
Remove TODO in live doc on installation guide

### DIFF
--- a/packages/docs/src/demos/handlebars-base-starterkit.md
+++ b/packages/docs/src/demos/handlebars-base-starterkit.md
@@ -1,5 +1,5 @@
 ---
-title: Handlebars Base Starter Kit
+title: Handlebars Base Starter Kit Preview
 description: The StarterKit for Handlebars is meant to be used as a demonstration of a Handlebars-based project in Pattern Lab.
 url: https://patternlab-handlebars-preview.netlify.com/?p=all
 category: starterkit

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -40,11 +40,13 @@ This will bring up an installation menu that presents the following steps:
 
 **`What initial patterns do you want included in your project?`** - Choose the <a href="/docs/starterkits/">Starterkit</a> you want to begin your project with. The options are:
 
-- **`Handlebars base patterns`** `(some basic patterns to get started with)` - TODO: include demo link
-- **`Handlebars demo patterns`** `(full demo website and patterns)` - TODO: include demo link
-- **`Twig (PHP) demo patterns`** `(full demo website and patterns)` - TODO: include demo link
+- **`Handlebars base patterns`** `(some basic patterns to get started with)`
+- **`Handlebars demo patterns`** `(full demo website and patterns)`
+- **`Twig (PHP) demo patterns`** `(full demo website and patterns)`
 - **`Custom starterkit`** - point to a custom Pattern Lab starterkit TODO: include instructions on including custom starterkits
 - **`Blank project (no patterns)`** - This won't include any initial patterns in your project so you can start completely from scratch
+
+You can find all starter kits on our [demos page](/demos/)
 
 ## Step 6: Confirm your choices
 


### PR DESCRIPTION
Summary of changes:
I just found `TODO: include demo link` on [installing-pattern-lab](https://patternlab.io/docs/installing-pattern-lab/). we should prevent those TODO statements in our live documentation. If it is planned to add something, please open a pr with those ideas or an issue.
