### PR TITLE
Fix title is overlapping expand button on view all page

### DIFF
--- a/packages/uikit-workshop/src/sass/scss/04-components/_pattern.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_pattern.scss
@@ -26,6 +26,10 @@
   font-size: 90%;
   color: $pl-color-gray-55;
 
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
   &:empty {
     padding: 0;
   }
@@ -68,10 +72,7 @@
 */
 .pl-c-pattern__extra-toggle {
   font-size: 0.8rem;
-  position: absolute;
-  bottom: -1px;
-  right: 0;
-  z-index: 1;
+  margin-bottom: -1px;
   padding: 0.4rem 0.5rem;
   color: $pl-color-gray-55;
   background-color: transparent;


### PR DESCRIPTION
Summary of changes:
The issue does not appear very often, but it sometimes appeared for longer pattern names on mobile screen sizes.

When the pattern name is too long, it overlaps with the "Expand" button for the pattern documentation.
This small fix should resolve the issue.