### PR TITLE
Remove blocking padding/margin from drawer

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-drawer/pl-drawer.scss
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-drawer/pl-drawer.scss
@@ -66,8 +66,6 @@ pl-drawer {
   transform: translate3d(0, 0, 0);
   will-change: height;
   overflow: hidden;
-  margin-top: calc(#{$pl-drawer-resizer-height * -1} + 1px);
-  padding-top: $pl-drawer-resizer-height;
 }
 
 .pl-c-drawer__wrapper > * {


### PR DESCRIPTION
Closes #1122

Summary of changes:
Since the padding is always visible in the pattern lab drawer, even if the drawer is not available, for example, on the view all page, it could happen that elements are not clickable at the end of the page.
