### PR TITLE
Add retrieval for pattern order by prefixes to ensure previous behavior

### DIFF
--- a/packages/core/src/lib/object_factory.js
+++ b/packages/core/src/lib/object_factory.js
@@ -157,8 +157,8 @@ const Pattern = function(
   this.lineageR = [];
   this.lineageRIndex = [];
   this.isPseudoPattern = false;
-  this.order = Number.MAX_SAFE_INTEGER;
-  this.variantOrder = Number.MAX_SAFE_INTEGER;
+  this.order = 0;
+  this.variantOrder = 0;
   this.engine = patternEngines.getEngineForPattern(this);
 
   // TODO: Remove the following when ordering by file prefix gets obsolete
@@ -173,19 +173,10 @@ const Pattern = function(
     this.patternGroupData.order = info.patternSubgroupOrder;
   }
 
-  // TODO: Remove the following when ordering by file prefix gets obsolete
-  if (prefixMatcherDeprecationCheckOrder.test(this.fileName)) {
-    if (this.fileName.indexOf('~') === -1) {
-      this.order = this.setPatternOrderDataForInfo(this.fileName);
-    } else {
-      this.variantOrder = this.setPatternOrderDataForInfo(this.fileName);
-    }
-  }
-
   /**
    * Determines if this pattern needs to be recompiled.
    *
-   * @see {@link CompileState}*/
+   * @ee {@link CompileState}*/
   this.compileState = null;
 
   /**
@@ -334,7 +325,7 @@ Pattern.prototype = {
     const match = pathStr.match(prefixMatcherDeprecationCheckOrder);
     return match && match.length >= 1
       ? pathStr.match(prefixMatcherDeprecationCheckOrder)[1].replace('-', '')
-      : Number.MAX_SAFE_INTEGER;
+      : 0;
   },
 
   /**
@@ -379,14 +370,12 @@ Pattern.prototype = {
       info.shortNotation = pathObj.dir
         .split(/\/|\\/, 2)
         .map((o, i) => {
-          // TODO: Remove when prefix gets deprecated
           if (i === 0) {
             info.patternGroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o
             );
           }
 
-          // TODO: Remove when prefix gets deprecated
           if (i === 1) {
             info.patternSubgroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o

--- a/packages/core/src/lib/object_factory.js
+++ b/packages/core/src/lib/object_factory.js
@@ -173,10 +173,19 @@ const Pattern = function(
     this.patternGroupData.order = info.patternSubgroupOrder;
   }
 
+  // TODO: Remove the following when ordering by file prefix gets obsolete
+  if (prefixMatcherDeprecationCheckOrder.test(this.fileName)) {
+    if (this.fileName.indexOf('~') === -1) {
+      this.order = this.setPatternOrderDataForInfo(this.fileName);
+    } else {
+      this.variantOrder = this.setPatternOrderDataForInfo(this.fileName);
+    }
+  }
+
   /**
    * Determines if this pattern needs to be recompiled.
    *
-   * @ee {@link CompileState}*/
+   * @see {@link CompileState}*/
   this.compileState = null;
 
   /**
@@ -371,12 +380,14 @@ Pattern.prototype = {
         .split(/\/|\\/, 2)
         .map((o, i) => {
           if (i === 0) {
+            // TODO: Remove when prefix gets deprecated
             info.patternGroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o
             );
           }
 
           if (i === 1) {
+            // TODO: Remove when prefix gets deprecated
             info.patternSubgroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o
             );

--- a/packages/core/src/lib/object_factory.js
+++ b/packages/core/src/lib/object_factory.js
@@ -157,8 +157,8 @@ const Pattern = function(
   this.lineageR = [];
   this.lineageRIndex = [];
   this.isPseudoPattern = false;
-  this.order = 0;
-  this.variantOrder = 0;
+  this.order = Number.MAX_SAFE_INTEGER;
+  this.variantOrder = Number.MAX_SAFE_INTEGER;
   this.engine = patternEngines.getEngineForPattern(this);
 
   // TODO: Remove the following when ordering by file prefix gets obsolete
@@ -173,10 +173,19 @@ const Pattern = function(
     this.patternGroupData.order = info.patternSubgroupOrder;
   }
 
+  // TODO: Remove the following when ordering by file prefix gets obsolete
+  if (prefixMatcherDeprecationCheckOrder.test(this.fileName)) {
+    if (this.fileName.indexOf('~') === -1) {
+      this.order = this.setPatternOrderDataForInfo(this.fileName);
+    } else {
+      this.variantOrder = this.setPatternOrderDataForInfo(this.fileName);
+    }
+  }
+
   /**
    * Determines if this pattern needs to be recompiled.
    *
-   * @ee {@link CompileState}*/
+   * @see {@link CompileState}*/
   this.compileState = null;
 
   /**
@@ -325,7 +334,7 @@ Pattern.prototype = {
     const match = pathStr.match(prefixMatcherDeprecationCheckOrder);
     return match && match.length >= 1
       ? pathStr.match(prefixMatcherDeprecationCheckOrder)[1].replace('-', '')
-      : 0;
+      : Number.MAX_SAFE_INTEGER;
   },
 
   /**
@@ -370,12 +379,14 @@ Pattern.prototype = {
       info.shortNotation = pathObj.dir
         .split(/\/|\\/, 2)
         .map((o, i) => {
+          // TODO: Remove when prefix gets deprecated
           if (i === 0) {
             info.patternGroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o
             );
           }
 
+          // TODO: Remove when prefix gets deprecated
           if (i === 1) {
             info.patternSubgroupOrder = Pattern.prototype.setPatternOrderDataForInfo(
               o

--- a/packages/core/src/lib/ui_builder.js
+++ b/packages/core/src/lib/ui_builder.js
@@ -184,7 +184,7 @@ const ui_builder = function() {
       order:
         pattern.patternGroupData && pattern.patternGroupData.order
           ? Number(pattern.patternGroupData.order)
-          : Number.MAX_SAFE_INTEGER,
+          : 0,
     });
 
     patternlab.patternGroups = _.sortBy(
@@ -255,7 +255,7 @@ const ui_builder = function() {
       order:
         pattern.patternSubgroupData && pattern.patternSubgroupData.order
           ? Number(pattern.patternSubgroupData.order)
-          : Number.MAX_SAFE_INTEGER,
+          : 0,
     });
 
     patternGroup.patternGroupItems = _.sortBy(
@@ -279,8 +279,8 @@ const ui_builder = function() {
       patternPath: pattern.patternLink,
       name: pattern.name,
       isDocPattern: false,
-      order: Number(pattern.order) || Number.MAX_SAFE_INTEGER, // Failsafe is someone entered a string
-      variantOrder: Number(pattern.variantOrder) || Number.MAX_SAFE_INTEGER, // Failsafe is someone entered a string
+      order: Number(pattern.order) || 0, // Failsafe is someone entered a string
+      variantOrder: Number(pattern.variantOrder) || 0, // Failsafe is someone entered a string
     };
   }
 
@@ -499,9 +499,9 @@ const ui_builder = function() {
             );
           });
 
-          return sg ? sg.order : Number.MAX_SAFE_INTEGER;
+          return sg ? sg.order : 0;
         } else {
-          return Number.MAX_SAFE_INTEGER;
+          return 0;
         }
       },
     ]);

--- a/packages/core/src/lib/ui_builder.js
+++ b/packages/core/src/lib/ui_builder.js
@@ -184,7 +184,7 @@ const ui_builder = function() {
       order:
         pattern.patternGroupData && pattern.patternGroupData.order
           ? Number(pattern.patternGroupData.order)
-          : 0,
+          : Number.MAX_SAFE_INTEGER,
     });
 
     patternlab.patternGroups = _.sortBy(
@@ -255,7 +255,7 @@ const ui_builder = function() {
       order:
         pattern.patternSubgroupData && pattern.patternSubgroupData.order
           ? Number(pattern.patternSubgroupData.order)
-          : 0,
+          : Number.MAX_SAFE_INTEGER,
     });
 
     patternGroup.patternGroupItems = _.sortBy(
@@ -279,8 +279,8 @@ const ui_builder = function() {
       patternPath: pattern.patternLink,
       name: pattern.name,
       isDocPattern: false,
-      order: Number(pattern.order) || 0, // Failsafe is someone entered a string
-      variantOrder: Number(pattern.variantOrder) || 0, // Failsafe is someone entered a string
+      order: Number(pattern.order) || Number.MAX_SAFE_INTEGER, // Failsafe is someone entered a string
+      variantOrder: Number(pattern.variantOrder) || Number.MAX_SAFE_INTEGER, // Failsafe is someone entered a string
     };
   }
 
@@ -499,9 +499,9 @@ const ui_builder = function() {
             );
           });
 
-          return sg ? sg.order : 0;
+          return sg ? sg.order : Number.MAX_SAFE_INTEGER;
         } else {
-          return 0;
+          return Number.MAX_SAFE_INTEGER;
         }
       },
     ]);


### PR DESCRIPTION
Summary of changes:
On Gitter, we got the message that the ordering is not behaving as it previously did.
This issue occurred because the order prefix is just removed but not taken into account.

With this small change, the ordering issue for older projects should be fixed.

