### PR TITLE
Fix pseudo pattern cannot override hidden frontmatter

### DIFF
--- a/packages/core/src/lib/readDocumentation.js
+++ b/packages/core/src/lib/readDocumentation.js
@@ -41,7 +41,7 @@ module.exports = function(pattern, patternlab, isVariant) {
       if (markdownObject.order) {
         pattern[isVariant ? 'variantOrder' : 'order'] = markdownObject.order;
       }
-      if (markdownObject.hidden) {
+      if (markdownObject.hasOwnProperty('hidden')) {
         pattern.hidden = markdownObject.hidden;
       }
       if (markdownObject.excludeFromStyleguide) {


### PR DESCRIPTION
Closes #1284

Summary of changes:
Adds the ability to allow overriding the frontmatter `hidden` for pseudo patterns.