### PR TITLE
fix(demopage): switched to HTTPS URLs for image placeholders

### DIFF
--- a/packages/starterkit-handlebars-demo/dist/_data/blocks.json
+++ b/packages/starterkit-handlebars-demo/dist/_data/blocks.json
@@ -1,6 +1,6 @@
 {
     "stackedBlockMedia": {
-        "src": "http://via.placeholder.com/600x400"
+        "src": "https://via.placeholder.com/600x400"
     },
     "stripeField": true,
     "cartPrice": {

--- a/packages/starterkit-handlebars-demo/dist/_data/images.json
+++ b/packages/starterkit-handlebars-demo/dist/_data/images.json
@@ -1,5 +1,5 @@
 {
-    "src" : "http://via.placeholder.com/1200x800",
+    "src" : "https://via.placeholder.com/1200x800",
     "alt": "landscape image",
     "logoImg" : "../../images/logo.png"
 }

--- a/packages/starterkit-handlebars-demo/dist/_data/lists.json
+++ b/packages/starterkit-handlebars-demo/dist/_data/lists.json
@@ -4,7 +4,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -15,7 +15,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -26,7 +26,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -37,7 +37,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -48,7 +48,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -59,7 +59,7 @@
 			"styleModifier": "",
 			"url": "#",
 			"stackedBlockMedia": {
-				"src": "http://via.placeholder.com/600x400",
+				"src": "https://via.placeholder.com/600x400",
 				"alt": "placeholder image"
 			},
 			"headline": "Heading ipsum dolor sit (39 characters)",
@@ -70,7 +70,7 @@
 	"stripeList": [
 		{
 			"url": "#",
-			"src": "http://via.placeholder.com/495x330",
+			"src": "https://via.placeholder.com/495x330",
 			"alt": "placeholder image",
 			"headline": "product item",
 			"cartPrice": {
@@ -80,7 +80,7 @@
 		},
 		{
 			"url": "#",
-			"src": "http://via.placeholder.com/495x330",
+			"src": "https://via.placeholder.com/495x330",
 			"alt": "placeholder image",
 			"headline": "product item",
 			"cartPrice": {

--- a/packages/starterkit-handlebars-demo/dist/_patterns/atoms/images/stacked-block-image.json
+++ b/packages/starterkit-handlebars-demo/dist/_patterns/atoms/images/stacked-block-image.json
@@ -1,3 +1,3 @@
 {
-	"src": "http://via.placeholder.com/600x400"
+	"src": "https://via.placeholder.com/600x400"
 }

--- a/packages/starterkit-handlebars-demo/dist/_patterns/molecules/blocks/stripe.json
+++ b/packages/starterkit-handlebars-demo/dist/_patterns/molecules/blocks/stripe.json
@@ -1,3 +1,3 @@
 {
-    "src": "http://via.placeholder.com/495x330"
+    "src": "https://via.placeholder.com/495x330"
 }


### PR DESCRIPTION
Closes #1288

Summary of changes:
Switched from HTTP to HTTPS URLs for the image placeholders by the online service via.placeholder.com.

In case of the page being served via HTTPS (like https://patternlab-handlebars-preview.netlify.app/) you'll elsewhere get browsers warnings and errors of any kind. In the unlikely case that the demo pages would get served via HTTP, there's no downside of these references to HTTPS instead.