### PR TITLE
Fix the hijacked podcast link

### DIFF
--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -29,7 +29,7 @@ title: Resources
 
 ## Podcasts
 
-- [Dave Olsen talking Pattern Lab 2 on Non-Breaking Space Podcast](https://goodstuff.fm/nbsp/86)
+- [Dave Olsen talking Pattern Lab 2 on Non-Breaking Space Podcast](https://open.spotify.com/episode/4IMyd92WWZyaXP04Unxdip)
 - [Brian Muenzenmeyer talking Pattern Lab 2 on the MS DEV SHOW Podcast](https://msdevshow.com/2015/12/pattern-lab-with-brian-muenzenmeyer/)
 
 ## Presentations


### PR DESCRIPTION
The original domain must have expired. It has been taken over by the porn site. 
Found an alternative URL, since I wanted to listen to the episode anyway.

<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes #

Summary of changes: Switched the link to alternative player
