### PR TITLE
Fix twig starterkit npm urls

### DIFF
--- a/packages/core/src/lib/readDocumentation.js
+++ b/packages/core/src/lib/readDocumentation.js
@@ -103,7 +103,7 @@ module.exports = function(pattern, patternlab, isVariant) {
       }
     } catch (err) {
       // do nothing when file not found
-      if (err.code !== 'ENOENT') {
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
         logger.warning(
           `There was an error setting pattern group data after markdown parsing for ${path.join(
             patternlab.config.paths.source.patterns,
@@ -139,7 +139,7 @@ module.exports = function(pattern, patternlab, isVariant) {
       }
     } catch (err) {
       // do nothing when file not found
-      if (err.code !== 'ENOENT') {
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
         logger.warning(
           `There was an error setting pattern subgroup data after markdown parsing for ${path.join(
             patternlab.config.paths.source.patterns,

--- a/packages/core/src/lib/readDocumentation.js
+++ b/packages/core/src/lib/readDocumentation.js
@@ -82,70 +82,74 @@ module.exports = function(pattern, patternlab, isVariant) {
 
   // Read Documentation for Pattern-Group
   // Use this approach, since pattern lab is a pattern driven software
-  try {
+  if (pattern.patternGroup) {
     const groupRelPath = pattern.relPath.split(path.sep);
-    const markdownFileNameGroup = path.resolve(
-      patternlab.config.paths.source.patterns,
-      groupRelPath[0] || pattern.subdir,
-      GROUP_DOC_PREFIX + pattern.patternGroup + FILE_EXTENSION
-    );
-    const markdownFileContentsGroup = fs.readFileSync(
-      markdownFileNameGroup,
-      'utf8'
-    );
-    const markdownObjectGroup = markdown_parser.parse(
-      markdownFileContentsGroup
-    );
-
-    if (!_.isEmpty(markdownObjectGroup)) {
-      pattern.patternGroupData = markdownObjectGroup;
-    }
-  } catch (err) {
-    // do nothing when file not found
-    if (err.code !== 'ENOENT') {
-      logger.warning(
-        `There was an error setting pattern group data after markdown parsing for ${path.join(
-          patternlab.config.paths.source.patterns,
-          path.parse(pattern.subdir).dir,
-          GROUP_DOC_PREFIX + pattern.patternGroup + FILE_EXTENSION
-        )}`
+    try {
+      const markdownFileNameGroup = path.resolve(
+        patternlab.config.paths.source.patterns,
+        groupRelPath[0] || pattern.subdir,
+        GROUP_DOC_PREFIX + pattern.patternGroup + FILE_EXTENSION
       );
-      logger.warning(err);
+      const markdownFileContentsGroup = fs.readFileSync(
+        markdownFileNameGroup,
+        'utf8'
+      );
+      const markdownObjectGroup = markdown_parser.parse(
+        markdownFileContentsGroup
+      );
+
+      if (!_.isEmpty(markdownObjectGroup)) {
+        pattern.patternGroupData = markdownObjectGroup;
+      }
+    } catch (err) {
+      // do nothing when file not found
+      if (err.code !== 'ENOENT') {
+        logger.warning(
+          `There was an error setting pattern group data after markdown parsing for ${path.join(
+            patternlab.config.paths.source.patterns,
+            groupRelPath[0] || pattern.subdir,
+            GROUP_DOC_PREFIX + pattern.patternGroup + FILE_EXTENSION
+          )}`
+        );
+        logger.warning(err);
+      }
     }
   }
 
   // Read Documentation for Pattern-Subgroup
-  try {
+  if (pattern.patternSubgroup) {
     const subgroupRelPath = pattern.relPath.split(path.sep);
-    const markdownFileNameSubgroup = path.resolve(
-      patternlab.config.paths.source.patterns,
-      subgroupRelPath[0],
-      subgroupRelPath[1],
-      GROUP_DOC_PREFIX + pattern.patternSubgroup + FILE_EXTENSION
-    );
-    const markdownFileContentsSubgroup = fs.readFileSync(
-      markdownFileNameSubgroup,
-      'utf8'
-    );
-    const markdownObjectSubgroup = markdown_parser.parse(
-      markdownFileContentsSubgroup
-    );
-
-    if (!_.isEmpty(markdownObjectSubgroup)) {
-      pattern.patternSubgroupData = markdownObjectSubgroup;
-    }
-  } catch (err) {
-    // do nothing when file not found
-    if (err.code !== 'ENOENT') {
-      logger.warning(
-        `There was an error setting pattern subgroup data after markdown parsing for ${path.join(
-          patternlab.config.paths.source.patterns,
-          path.parse(pattern.subdir).dir,
-          path.parse(pattern.subdir).base,
-          GROUP_DOC_PREFIX + pattern.patternSubgroup + FILE_EXTENSION
-        )}`
+    try {
+      const markdownFileNameSubgroup = path.resolve(
+        patternlab.config.paths.source.patterns,
+        subgroupRelPath[0],
+        subgroupRelPath[1],
+        GROUP_DOC_PREFIX + pattern.patternSubgroup + FILE_EXTENSION
       );
-      logger.warning(err);
+      const markdownFileContentsSubgroup = fs.readFileSync(
+        markdownFileNameSubgroup,
+        'utf8'
+      );
+      const markdownObjectSubgroup = markdown_parser.parse(
+        markdownFileContentsSubgroup
+      );
+
+      if (!_.isEmpty(markdownObjectSubgroup)) {
+        pattern.patternSubgroupData = markdownObjectSubgroup;
+      }
+    } catch (err) {
+      // do nothing when file not found
+      if (err.code !== 'ENOENT') {
+        logger.warning(
+          `There was an error setting pattern subgroup data after markdown parsing for ${path.join(
+            patternlab.config.paths.source.patterns,
+            subgroupRelPath[0],
+            subgroupRelPath[1],
+            GROUP_DOC_PREFIX + pattern.patternSubgroup + FILE_EXTENSION
+          )}`
+        );
+        logger.warning(err);
+      }
     }
   }
 };

--- a/packages/starterkit-twig-demo/package.json
+++ b/packages/starterkit-twig-demo/package.json
@@ -5,7 +5,7 @@
   "main": "README.md",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pattern-lab/starterkit-twig-demo.git"
+    "url": "git+https://github.com/pattern-lab/patternlab-node.git"
   },
   "keywords": [
     "Pattern Lab",
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/pattern-lab/patternlab-node/issues"
   },
-  "homepage": "https://github.com/pattern-lab/patternlab-node/tree/master/packages/starterkit-twig-demo",
+  "homepage": "https://github.com/pattern-lab/patternlab-node/tree/dev/packages/starterkit-twig-demo",
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,10 +1710,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@basalt/twig-renderer@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@basalt/twig-renderer/-/twig-renderer-0.13.1.tgz#00d184b9397dbcb1661950e2554e6525d62506ec"
-  integrity sha512-MM7u2EouQ/NpaMRJyy+v0t4isFYOU65ZGHTKmnz126lhqgUqtBn0D0539dnTAoUq8iwUeQu6LU3HV/4Bz3fBDw==
+"@basalt/twig-renderer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@basalt/twig-renderer/-/twig-renderer-2.0.0.tgz#197e5d383035482a37215d48e5ae74dae210ef1d"
+  integrity sha512-FesNB7Mxh3P9xLkAS/Y3u3dFSUy15j1TvMTyyUrqXnJwTgViYyylbvAkx779pgVImJnAdFM3b5DsIOtl0yWBGQ==
   dependencies:
     "@babel/core" "^7.2.0"
     "@babel/preset-env" "^7.2.0"


### PR DESCRIPTION
Summary of changes:
While investigating some other issue, I saw that those links on npm are outdated and not matching the current source anymore.
