### PR TITLE
chore(docs): corrected the markdown syntax

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -194,7 +194,7 @@ For example, to export the navigation, header, and footer, one might do:
 
 ### patternMergeVariantArrays
 
-Used to override the merge behavior of pattern variants. For more information see [The Pseudo-Pattern File Data](docs/using-pseudo-patterns/#heading-the-pseudo-pattern-file data).
+Used to override the merge behavior of pattern variants. For more information see [The Pseudo-Pattern File Data](docs/using-pseudo-patterns/#heading-the-pseudo-pattern-file-data).
 
 - `true` will merge arrays of the pattern and pseudo-pattern with [lodash merge](https://lodash.com/docs/4.17.15#merge)
 - `false` will override arrays from the pattern with pseudo-patterns arrays


### PR DESCRIPTION
Summary of changes:
corrected the markdown syntax on one of the links in the page https://patternlab.io/docs/editing-the-configuration-options/#heading-patternmergevariantarrays especially to fix the incorrect rendering of the markdown code.