### PR TITLE
refactor(logging): aligned error messages with reporting criticality

### DIFF
--- a/packages/core/src/lib/buildFooter.js
+++ b/packages/core/src/lib/buildFooter.js
@@ -29,8 +29,8 @@ module.exports = function (patternlab, patternPartial, uikit) {
           'config.paths.source.data plus patterns data'
         );
       } catch (err) {
-        logger.warning('There was an error parsing JSON for patternlab.data');
-        logger.warning(err);
+        logger.error('There was an error parsing JSON for patternlab.data');
+        logger.error(err);
       }
       allFooterData.patternLabFoot = footerPartial;
 

--- a/packages/core/src/lib/compose.js
+++ b/packages/core/src/lib/compose.js
@@ -168,10 +168,10 @@ module.exports = async function (pattern, patternlab) {
               'config.paths.source.data global data'
             );
           } catch (err) {
-            logger.info(
+            logger.error(
               'There was an error parsing JSON for ' + pattern.relPath
             );
-            logger.info(err);
+            logger.error(err);
           }
           allFooterData = _.merge(allFooterData, pattern.jsonFileData);
           allFooterData.cacheBuster = patternlab.cacheBuster;

--- a/packages/core/src/lib/loadPattern.js
+++ b/packages/core/src/lib/loadPattern.js
@@ -94,10 +94,10 @@ module.exports = function (relPath, patternlab) {
       );
     }
   } catch (err) {
-    logger.warning(
+    logger.error(
       `There was an error parsing sibling JSON for ${currentPattern.relPath}`
     );
-    logger.warning(err);
+    logger.error(err);
   }
 
   //look for a listitems.json file for this template
@@ -118,10 +118,10 @@ module.exports = function (relPath, patternlab) {
       buildListItems(currentPattern);
     }
   } catch (err) {
-    logger.warning(
+    logger.error(
       `There was an error parsing sibling listitem JSON for ${currentPattern.relPath}`
     );
-    logger.warning(err);
+    logger.error(err);
   }
 
   //look for a markdown file for this template

--- a/packages/core/src/lib/parameter_hunter.js
+++ b/packages/core/src/lib/parameter_hunter.js
@@ -288,10 +288,10 @@ const parameter_hunter = function () {
             try {
               paramData = JSON.parse(paramStringWellFormed);
             } catch (err) {
-              logger.error(
+              logger.warning(
                 `There was an error parsing JSON for ${pattern.relPath}`
               );
-              logger.error(err);
+              logger.warning(err);
             }
 
             // resolve any pattern links that might be present

--- a/packages/core/src/lib/parameter_hunter.js
+++ b/packages/core/src/lib/parameter_hunter.js
@@ -289,7 +289,7 @@ const parameter_hunter = function () {
               paramData = JSON.parse(paramStringWellFormed);
             } catch (err) {
               logger.warning(
-                `There was an error parsing JSON for ${pattern.relPath}`
+                `There was a problem parsing JSON parameters for ${pattern.relPath}`
               );
               logger.warning(err);
             }

--- a/packages/core/src/lib/parameter_hunter.js
+++ b/packages/core/src/lib/parameter_hunter.js
@@ -288,10 +288,10 @@ const parameter_hunter = function () {
             try {
               paramData = JSON.parse(paramStringWellFormed);
             } catch (err) {
-              logger.warning(
+              logger.error(
                 `There was an error parsing JSON for ${pattern.relPath}`
               );
-              logger.warning(err);
+              logger.error(err);
             }
 
             // resolve any pattern links that might be present

--- a/packages/core/src/lib/parseLink.js
+++ b/packages/core/src/lib/parseLink.js
@@ -84,8 +84,8 @@ module.exports = function (patternlab, obj, key) {
   try {
     dataObj = JSON.parse(dataObjAsString);
   } catch (err) {
-    logger.warning(`There was an error parsing JSON for ${key}`);
-    logger.warning(err);
+    logger.error(`There was an error parsing JSON for ${key}`);
+    logger.error(err);
   }
 
   return dataObj;

--- a/packages/core/src/lib/pseudopattern_hunter.js
+++ b/packages/core/src/lib/pseudopattern_hunter.js
@@ -54,10 +54,10 @@ pseudopattern_hunter.prototype.find_pseudopatterns = function (
           fs.readFileSync(variantFileFullPath, 'utf8')
         );
       } catch (err) {
-        logger.warning(
+        logger.error(
           `There was an error parsing pseudopattern JSON for ${currentPattern.relPath}`
         );
-        logger.warning(err);
+        logger.error(err);
       }
 
       //extend any existing data with variant data

--- a/packages/core/src/lib/readDocumentation.js
+++ b/packages/core/src/lib/readDocumentation.js
@@ -73,10 +73,10 @@ module.exports = function (pattern, patternlab, isVariant) {
   } catch (err) {
     // do nothing when file not found
     if (err.code !== 'ENOENT') {
-      logger.warning(
+      logger.error(
         `There was an error setting pattern keys after markdown parsing of the companion file for pattern ${pattern.patternPartial}${FILE_EXTENSION}`
       );
-      logger.warning(err);
+      logger.error(err);
     }
   }
 

--- a/packages/plugin-tab/src/tab-loader.js
+++ b/packages/plugin-tab/src/tab-loader.js
@@ -64,7 +64,7 @@ async function findTab(patternlab, pattern) {
         }
 
         //copy the file to our output target if found
-        _.each(patternlab.uikits, uikit => {
+        _.each(patternlab.uikits, (uikit) => {
           fs.copySync(
             tabFileName,
             path.join(process.cwd(), uikit.outputDir, customFileTypeOutputPath)
@@ -72,7 +72,7 @@ async function findTab(patternlab, pattern) {
         });
       } else {
         //otherwise write nothing to the same location - this prevents GET errors on the tab.
-        _.each(patternlab.uikits, uikit => {
+        _.each(patternlab.uikits, (uikit) => {
           fs.outputFileSync(
             path.join(process.cwd(), uikit.outputDir, customFileTypeOutputPath),
             ''
@@ -80,11 +80,11 @@ async function findTab(patternlab, pattern) {
         });
       }
     } catch (err) {
-      console.log(
+      console.error(
         'plugin-tab: There was an error parsing sibling JSON for ' +
           pattern.relPath
       );
-      console.log(err);
+      console.error(err);
     }
   }
 }


### PR DESCRIPTION
Closes #1315

### Summary of changes:
If we call it an error in the logging message, we should even also mark it as an `error` instead of an `info` or a `warning`. This is as well related to console output depending on the log level setting within the configuration.

The changes on lines [67](https://github.com/pattern-lab/patternlab-node/compare/dev...mfranzke:refactor-error-loggings-criticality?expand=1#diff-cd60bcce639f789d86cf9f084eb2040fe547dab4b1846c903a3a6faa2889f427R67) and [75](https://github.com/pattern-lab/patternlab-node/compare/dev...mfranzke:refactor-error-loggings-criticality?expand=1#diff-cd60bcce639f789d86cf9f084eb2040fe547dab4b1846c903a3a6faa2889f427R75) within the file `packages/plugin-tab/src/tab-loader.js` are unrelated to the contents of this change request, but most likely triggered by automatic prettifying through `prettier`/`pretty-quick` by `husky` git commits.