### PR TITLE
Issue 1325: Correct create README.md

### DIFF
--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -12,5 +12,5 @@ This is the same as using the main Pattern Lab CLI's `init` command:
 
 ```bash
 npm i -g @pattern-lab/cli
-pattern-lab init
+patternlab init
 ```


### PR DESCRIPTION
This pull request corrects a typo in the README.md for the "create"
package, correcting the second documented command from `pattern-lab init`
to `patternlab init`.

Closes #1325

Summary of changes:

Updates the README.md to correct a typo in the documentation for the commands executed with `npm create pattern-lab`.  See summary above for more information.
