### PR TITLE
feat(docs): adding a sitemap.xml

### DIFF
--- a/packages/docs/src/404.md
+++ b/packages/docs/src/404.md
@@ -2,7 +2,7 @@
 title: '404 - not found'
 layout: layouts/page.njk
 permalink: 404.html
-eleventyExcludeFromCollections: true
+sitemapIgnore: true
 ---
 
 We’re sorry, but that content can’t be found. Please go [back to home](/).

--- a/packages/docs/src/_data/site.json
+++ b/packages/docs/src/_data/site.json
@@ -2,7 +2,7 @@
   "showThemeCredit": true,
   "name": "Pattern Lab",
   "shortDesc": "Pattern Lab is a frontend workshop environment that helps you build, view, test, and showcase your design system's UI components.",
-  "url": "https://patternlab.io/",
+  "url": "https://patternlab.io",
   "authorEmail": "brad@bradfrost.com",
   "authorHandle": "@bradfrost",
   "authorName": "Brad Frost",

--- a/packages/docs/src/_data/site.json
+++ b/packages/docs/src/_data/site.json
@@ -2,7 +2,7 @@
   "showThemeCredit": true,
   "name": "Pattern Lab",
   "shortDesc": "Pattern Lab is a frontend workshop environment that helps you build, view, test, and showcase your design system's UI components.",
-  "url": "https://patternlab.io",
+  "url": "https://patternlab.io/",
   "authorEmail": "brad@bradfrost.com",
   "authorHandle": "@bradfrost",
   "authorName": "Brad Frost",

--- a/packages/docs/src/admin.njk
+++ b/packages/docs/src/admin.njk
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 permalink: '/admin/index.html'
 ---
 <!doctype html>

--- a/packages/docs/src/admin.njk
+++ b/packages/docs/src/admin.njk
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: '/admin/index.html'
 ---
 <!doctype html>

--- a/packages/docs/src/admin.njk
+++ b/packages/docs/src/admin.njk
@@ -1,6 +1,6 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: '/admin/index.html'
+sitemapIgnore: true
 ---
 <!doctype html>
 <html>

--- a/packages/docs/src/archive.md
+++ b/packages/docs/src/archive.md
@@ -1,5 +1,5 @@
 ---
-eleventyExcludeFromCollections: true
 title: 'Posts Archive'
 layout: 'layouts/archive.njk'
+sitemapIgnore: true
 ---

--- a/packages/docs/src/archive.md
+++ b/packages/docs/src/archive.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: 'Posts Archive'
 layout: 'layouts/archive.njk'
 ---

--- a/packages/docs/src/archive.md
+++ b/packages/docs/src/archive.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: 'Posts Archive'
 layout: 'layouts/archive.njk'
 ---

--- a/packages/docs/src/demos.md
+++ b/packages/docs/src/demos.md
@@ -2,6 +2,8 @@
 layout: layouts/demos.njk
 title: Pattern Lab Demos
 category: getting-started
+sitemapPriority: '0.9'
+sitemapChangefreq: 'monthly'
 ---
 
 

--- a/packages/docs/src/demos.md
+++ b/packages/docs/src/demos.md
@@ -2,8 +2,6 @@
 layout: layouts/demos.njk
 title: Pattern Lab Demos
 category: getting-started
-sitemapPriority: '0.9'
-sitemapChangefreq: 'monthly'
 ---
 
 

--- a/packages/docs/src/demos.md
+++ b/packages/docs/src/demos.md
@@ -2,6 +2,7 @@
 layout: layouts/demos.njk
 title: Pattern Lab Demos
 category: getting-started
+sitemapPriority: '0.9'
 ---
 
 

--- a/packages/docs/src/demos.md
+++ b/packages/docs/src/demos.md
@@ -3,6 +3,7 @@ layout: layouts/demos.njk
 title: Pattern Lab Demos
 category: getting-started
 sitemapPriority: '0.9'
+sitemapChangefreq: 'monthly'
 ---
 
 

--- a/packages/docs/src/demos/bolt-design-systems.md
+++ b/packages/docs/src/demos/bolt-design-systems.md
@@ -8,4 +8,5 @@ tags:
   - demo-content
   - code
 refLink: https://boltdesignsystem.com/pattern-lab/?p=pages-d8-homepage
+sitemapIgnore: true
 ---

--- a/packages/docs/src/demos/handlebars-base-starterkit.md
+++ b/packages/docs/src/demos/handlebars-base-starterkit.md
@@ -8,4 +8,5 @@ tags:
   - demo-content
   - code
 refLink: https://patternlab-handlebars-preview.netlify.app/?p=all
+sitemapIgnore: true
 ---

--- a/packages/docs/src/demos/handlebars-demo-starterkit.md
+++ b/packages/docs/src/demos/handlebars-demo-starterkit.md
@@ -8,4 +8,5 @@ tags:
   - demo-content
   - code
 refLink: https://patternlab-handlebars-preview.netlify.app/?p=all
+sitemapIgnore: true
 ---

--- a/packages/docs/src/demos/handlebars-vanilla-starterkit.md
+++ b/packages/docs/src/demos/handlebars-vanilla-starterkit.md
@@ -8,4 +8,5 @@ tags:
   - demo-content
   - code
 refLink: https://patternlab-handlebars-preview.netlify.app/?p=all
+sitemapIgnore: true
 ---

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: DOCS DOCS DOCS
 tags:
   - demo-content
@@ -7,6 +8,7 @@ tags:
 eleventyNavigation:
   key: DOCS DOCS DOCS
   order: 300
+sitemapPriority: '0.8'
 ---
 
 The best way to demo a code post is to display a real life post, so check out this one from [andy-bell.design](https://andy-bell.design/wrote/creating-a-full-bleed-css-utility/) about a full bleed CSS utility.

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: DOCS DOCS DOCS
 tags:
   - demo-content
@@ -8,7 +7,6 @@ tags:
 eleventyNavigation:
   key: DOCS DOCS DOCS
   order: 300
-sitemapPriority: '0.8'
 ---
 
 The best way to demo a code post is to display a real life post, so check out this one from [andy-bell.design](https://andy-bell.design/wrote/creating-a-full-bleed-css-utility/) about a full bleed CSS utility.

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -7,6 +7,7 @@ tags:
 eleventyNavigation:
   key: DOCS DOCS DOCS
   order: 300
+sitemapPriority: '0.8'
 ---
 
 The best way to demo a code post is to display a real life post, so check out this one from [andy-bell.design](https://andy-bell.design/wrote/creating-a-full-bleed-css-utility/) about a full bleed CSS utility.

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: DOCS DOCS DOCS
 tags:
   - demo-content

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -7,7 +7,6 @@ tags:
 eleventyNavigation:
   key: DOCS DOCS DOCS
   order: 300
-sitemapPriority: '0.8'
 ---
 
 The best way to demo a code post is to display a real life post, so check out this one from [andy-bell.design](https://andy-bell.design/wrote/creating-a-full-bleed-css-utility/) about a full bleed CSS utility.

--- a/packages/docs/src/docs/a-post-with-code-samples.md
+++ b/packages/docs/src/docs/a-post-with-code-samples.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: DOCS DOCS DOCS
 tags:
   - demo-content
@@ -9,6 +8,7 @@ eleventyNavigation:
   key: DOCS DOCS DOCS
   order: 300
 sitemapPriority: '0.8'
+sitemapIgnore: true
 ---
 
 The best way to demo a code post is to display a real life post, so check out this one from [andy-bell.design](https://andy-bell.design/wrote/creating-a-full-bleed-css-utility/) about a full bleed CSS utility.

--- a/packages/docs/src/docs/advanced-auto-regenerate.md
+++ b/packages/docs/src/docs/advanced-auto-regenerate.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: Watching for Changes and Auto Regenerating Patterns
 tags:
   - docs

--- a/packages/docs/src/docs/advanced-auto-regenerate.md
+++ b/packages/docs/src/docs/advanced-auto-regenerate.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: Watching for Changes and Auto Regenerating Patterns
 tags:
   - docs
@@ -9,6 +8,7 @@ eleventyNavigation:
   parent: advanced
   order: 300
 sitemapPriority: '0.8'
+sitemapIgnore: true
 ---
 
 Pattern Lab has the ability to watch for changes to patterns and frontend assets. When these files change, it will automatically rebuild the entire Pattern Lab website. You simply make your changes, save the file, and Pattern Lab will take care of the rest.

--- a/packages/docs/src/docs/advanced-auto-regenerate.md
+++ b/packages/docs/src/docs/advanced-auto-regenerate.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: Watching for Changes and Auto Regenerating Patterns
 tags:
   - docs

--- a/packages/docs/src/docs/advanced-auto-regenerate.md
+++ b/packages/docs/src/docs/advanced-auto-regenerate.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   key: Watching for Changes and Auto Regenerating Patterns
   parent: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 Pattern Lab has the ability to watch for changes to patterns and frontend assets. When these files change, it will automatically rebuild the entire Pattern Lab website. You simply make your changes, save the file, and Pattern Lab will take care of the rest.

--- a/packages/docs/src/docs/advanced-auto-regenerate.md
+++ b/packages/docs/src/docs/advanced-auto-regenerate.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   key: Watching for Changes and Auto Regenerating Patterns
   parent: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 Pattern Lab has the ability to watch for changes to patterns and frontend assets. When these files change, it will automatically rebuild the entire Pattern Lab website. You simply make your changes, save the file, and Pattern Lab will take care of the rest.

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   key: getting-started
   title: Editing the Configuration Options
   order: 30
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Pattern Lab Node comes with a configuration file [(`patternlab-config.json`)](https://github.com/pattern-lab/patternlab-node/blob/master/packages/core/patternlab-config.json) that allows you to modify certain aspects of the system. The latest default values are included within. This file is shipped within [the editions](https://github.com/pattern-lab?utf8=%E2%9C%93&query=edition-node) or can be supplied from core and the command line interface. Below is a description of each configuration option and how it affects Pattern Lab Node.

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   key: getting-started
   title: Editing the Configuration Options
   order: 30
+sitemapPriority: '0.8'
 ---
 
 Pattern Lab Node comes with a configuration file [(`patternlab-config.json`)](https://github.com/pattern-lab/patternlab-node/blob/master/packages/core/patternlab-config.json) that allows you to modify certain aspects of the system. The latest default values are included within. This file is shipped within [the editions](https://github.com/pattern-lab?utf8=%E2%9C%93&query=edition-node) or can be supplied from core and the command line interface. Below is a description of each configuration option and how it affects Pattern Lab Node.

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   title: Editing the Configuration Options
   order: 30
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern Lab Node comes with a configuration file [(`patternlab-config.json`)](https://github.com/pattern-lab/patternlab-node/blob/master/packages/core/patternlab-config.json) that allows you to modify certain aspects of the system. The latest default values are included within. This file is shipped within [the editions](https://github.com/pattern-lab?utf8=%E2%9C%93&query=edition-node) or can be supplied from core and the command line interface. Below is a description of each configuration option and how it affects Pattern Lab Node.

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   key: getting-started
   title: Editing the Configuration Options
   order: 30
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern Lab Node comes with a configuration file [(`patternlab-config.json`)](https://github.com/pattern-lab/patternlab-node/blob/master/packages/core/patternlab-config.json) that allows you to modify certain aspects of the system. The latest default values are included within. This file is shipped within [the editions](https://github.com/pattern-lab?utf8=%E2%9C%93&query=edition-node) or can be supplied from core and the command line interface. Below is a description of each configuration option and how it affects Pattern Lab Node.

--- a/packages/docs/src/docs/advanced-ecosystem-overview.md
+++ b/packages/docs/src/docs/advanced-ecosystem-overview.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   key: advanced
   title: Overview of Pattern Lab's Ecosystem
   order: 300
+sitemapPriority: '0.8'
 ---
 
 Pattern Lab 2 introduces the beginnings of an ecosystem that will allow teams to mix, match and extend Pattern Lab to meet their specific needs. It will also make it easier for the Pattern Lab team to push out new features. Documentation that explains how best to take advantage of the ecosystem will be released in the coming weeks.

--- a/packages/docs/src/docs/advanced-ecosystem-overview.md
+++ b/packages/docs/src/docs/advanced-ecosystem-overview.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   key: advanced
   title: Overview of Pattern Lab's Ecosystem
   order: 300
-sitemapPriority: '0.8'
 ---
 
 Pattern Lab 2 introduces the beginnings of an ecosystem that will allow teams to mix, match and extend Pattern Lab to meet their specific needs. It will also make it easier for the Pattern Lab team to push out new features. Documentation that explains how best to take advantage of the ecosystem will be released in the coming weeks.

--- a/packages/docs/src/docs/advanced-exporting-patterns.md
+++ b/packages/docs/src/docs/advanced-exporting-patterns.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Exporting Patterns
   key: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 While the Pattern Lab website is great for design, iteration, alignment, and discussion - you may find yourself wanting to export whole pattern markup snippets into a different environment.

--- a/packages/docs/src/docs/advanced-exporting-patterns.md
+++ b/packages/docs/src/docs/advanced-exporting-patterns.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Exporting Patterns
   key: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 While the Pattern Lab website is great for design, iteration, alignment, and discussion - you may find yourself wanting to export whole pattern markup snippets into a different environment.

--- a/packages/docs/src/docs/advanced-keyboard-shortcuts.md
+++ b/packages/docs/src/docs/advanced-keyboard-shortcuts.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Keyboard Shortcuts
   key: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 > **Note:** This feature is currently disabled. It will be back in a future release of `styleguidekit-assets-default`.

--- a/packages/docs/src/docs/advanced-keyboard-shortcuts.md
+++ b/packages/docs/src/docs/advanced-keyboard-shortcuts.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Keyboard Shortcuts
   key: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 > **Note:** This feature is currently disabled. It will be back in a future release of `styleguidekit-assets-default`.

--- a/packages/docs/src/docs/advanced-pattern-lab-nav.md
+++ b/packages/docs/src/docs/advanced-pattern-lab-nav.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Modifying Pattern Lab's Navigation
   key: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 When sharing Pattern Lab with a client it may be beneficial to turn-off certain elements in the default navigation. To turn-off navigation elements, alter the flags inside the `ishControlsHide` object within `patternlab-config.json` and then re-generate the site. The following keys are supported and will hide their respective elements if toggled on:

--- a/packages/docs/src/docs/advanced-pattern-lab-nav.md
+++ b/packages/docs/src/docs/advanced-pattern-lab-nav.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Modifying Pattern Lab's Navigation
   key: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 When sharing Pattern Lab with a client it may be beneficial to turn-off certain elements in the default navigation. To turn-off navigation elements, alter the flags inside the `ishControlsHide` object within `patternlab-config.json` and then re-generate the site. The following keys are supported and will hide their respective elements if toggled on:

--- a/packages/docs/src/docs/advanced-starterkits.md
+++ b/packages/docs/src/docs/advanced-starterkits.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Starterkits
   key: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/overview-of-pattern-lab's-ecosystem/) An agency or team could use it for each new client or project. [Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design.

--- a/packages/docs/src/docs/advanced-starterkits.md
+++ b/packages/docs/src/docs/advanced-starterkits.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Starterkits
   key: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 Starterkits are a potent way create or augment a Pattern Lab instance with a baseline set of patterns and assets. They are an important part of the [Pattern Lab Ecosystem](/docs/overview-of-pattern-lab's-ecosystem/) An agency or team could use it for each new client or project. [Several starterkits](https://github.com/pattern-lab?utf8=%E2%9C%93&q=starterkit&type=&language=) already exist to kick your project off, whether you’re looking for a blank start, begin with a demo that showcases Pattern Lab’s features, or start with a popular framework like Bootstrap, Foundation, or Material Design.

--- a/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
+++ b/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Template Language and PatternEngines
   key: advanced
   order: 300
+sitemapPriority: '0.8'
 ---
 
 By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/using-pattern-parameters/). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.

--- a/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
+++ b/packages/docs/src/docs/advanced-template-language-and-pattern-engines.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Template Language and PatternEngines
   key: advanced
   order: 300
-sitemapPriority: '0.8'
 ---
 
 By default Pattern Lab uses the Mustache template language, extended with [pattern parameters](/docs/using-pattern-parameters/). PatternEngines let you add support for a template language of your personal choice. Each PatternEngine has it's own set of features and caveats.

--- a/packages/docs/src/docs/changes-1-to-2.md
+++ b/packages/docs/src/docs/changes-1-to-2.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: Pattern Lab 1 to Pattern Lab 2 Changes
 tags:
   - docs

--- a/packages/docs/src/docs/changes-1-to-2.md
+++ b/packages/docs/src/docs/changes-1-to-2.md
@@ -1,11 +1,11 @@
 ---
-eleventyExcludeFromCollections: true
 title: Pattern Lab 1 to Pattern Lab 2 Changes
 tags:
   - docs
 eleventyNavigation:
   title: Pattern Lab 1 to Pattern Lab 2 Changes
   order: 300
+sitemapIgnore: true
 ---
 
 The list of features is coming soon.

--- a/packages/docs/src/docs/changes-1-to-2.md
+++ b/packages/docs/src/docs/changes-1-to-2.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: Pattern Lab 1 to Pattern Lab 2 Changes
 tags:
   - docs

--- a/packages/docs/src/docs/data-json-mustache.md
+++ b/packages/docs/src/docs/data-json-mustache.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Introduction to JSON & Mustache Variables
   key: data
   order: 300
+sitemapPriority: '0.8'
 ---
 
 > This documentation is provided as a simple introduction to using one of the supported data types and one of the supported PatternEngines. The best reference for this topic is the [Mustache documentation](http://mustache.github.io/mustache.5.html) but this should provide a good beginner's primer.

--- a/packages/docs/src/docs/data-json-mustache.md
+++ b/packages/docs/src/docs/data-json-mustache.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Introduction to JSON & Mustache Variables
   key: data
   order: 300
-sitemapPriority: '0.8'
 ---
 
 > This documentation is provided as a simple introduction to using one of the supported data types and one of the supported PatternEngines. The best reference for this topic is the [Mustache documentation](http://mustache.github.io/mustache.5.html) but this should provide a good beginner's primer.

--- a/packages/docs/src/docs/data-link-variable.md
+++ b/packages/docs/src/docs/data-link-variable.md
@@ -5,6 +5,7 @@ eleventyNavigation:
   title: Linking to Patterns with Pattern Lab's Default `link` Variable
   key: data
   order: 100
+sitemapPriority: '0.8'
 ---
 
 You can build patterns that link to one another to help simulate using a real website. This is especially useful when working with the Pages and Templates pattern types. Rather than having to remember the actual path to a pattern you can use the same shorthand syntax you'd use to include one pattern within another. **Important:** Pattern links _do not_ support the same fuzzy matching of names as the shorthand partials syntax does. The basic format is:

--- a/packages/docs/src/docs/data-link-variable.md
+++ b/packages/docs/src/docs/data-link-variable.md
@@ -5,7 +5,6 @@ eleventyNavigation:
   title: Linking to Patterns with Pattern Lab's Default `link` Variable
   key: data
   order: 100
-sitemapPriority: '0.8'
 ---
 
 You can build patterns that link to one another to help simulate using a real website. This is especially useful when working with the Pages and Templates pattern types. Rather than having to remember the actual path to a pattern you can use the same shorthand syntax you'd use to include one pattern within another. **Important:** Pattern links _do not_ support the same fuzzy matching of names as the shorthand partials syntax does. The basic format is:

--- a/packages/docs/src/docs/data-overview.md
+++ b/packages/docs/src/docs/data-overview.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Overview of Data
   key: data
   order: 300
+sitemapPriority: '0.8'
 ---
 
 The primary default global source of data used when rendering Pattern Lab patterns can be found in `./source/_data/`.

--- a/packages/docs/src/docs/data-overview.md
+++ b/packages/docs/src/docs/data-overview.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Overview of Data
   key: data
   order: 300
-sitemapPriority: '0.8'
 ---
 
 The primary default global source of data used when rendering Pattern Lab patterns can be found in `./source/_data/`.

--- a/packages/docs/src/docs/data-pattern-specific.md
+++ b/packages/docs/src/docs/data-pattern-specific.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Creating Pattern-specific Values
   key: data
   order: 300
-sitemapPriority: '0.8'
 ---
 
 > **Note:** This article uses JSON because it is a standard between with the Node version of Pattern Lab.

--- a/packages/docs/src/docs/data-pattern-specific.md
+++ b/packages/docs/src/docs/data-pattern-specific.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Creating Pattern-specific Values
   key: data
   order: 300
+sitemapPriority: '0.8'
 ---
 
 > **Note:** This article uses JSON because it is a standard between with the Node version of Pattern Lab.

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Editing Pattern Lab Source Files
   key: getting-started
   order: 20
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/managing-pattern-assets/). Each time your site is generated your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: getting-started
   order: 20
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/managing-pattern-assets/). Each time your site is generated your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Editing Pattern Lab Source Files
   key: getting-started
   order: 20
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/managing-pattern-assets/). Each time your site is generated your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Editing Pattern Lab Source Files
   key: getting-started
   order: 20
+sitemapPriority: '0.8'
 ---
 
 When editing Pattern Lab you must put your files and edit them in the `./source/` directory. This includes your static assets like [JavaScript, CSS, and images](/docs/managing-pattern-assets/). Each time your site is generated your patterns will be compiled and your static assets will be moved to the `./public/` directory. Because of this you **should not edit** the files in the `./public/` directory.

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Installing Pattern Lab
   key: getting-started
   order: 0
-sitemapPriority: '0.9'
-sitemapChangefreq: 'monthly'
 ---
 
 ## Step 1: Install requirements

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Installing Pattern Lab
   key: getting-started
   order: 0
+sitemapPriority: '0.9'
 ---
 
 ## Step 1: Install requirements

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: getting-started
   order: 0
 sitemapPriority: '0.9'
+sitemapChangefreq: 'monthly'
 ---
 
 ## Step 1: Install requirements

--- a/packages/docs/src/docs/installation.md
+++ b/packages/docs/src/docs/installation.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Installing Pattern Lab
   key: getting-started
   order: 0
+sitemapPriority: '0.9'
+sitemapChangefreq: 'monthly'
 ---
 
 ## Step 1: Install requirements

--- a/packages/docs/src/docs/pattern-add-new.md
+++ b/packages/docs/src/docs/pattern-add-new.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Adding New Patterns
   key: patterns
   order: 70
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To add new patterns to the Node version of Pattern Lab just add new Mustache templates under the appropriate pattern type or pattern subgroup directories in `./source/_patterns`. For example, let's add a new pattern under the pattern type "molecules" and the pattern sub-type "blocks". The `./source/_patterns/molecules/blocks/` directory looks like:

--- a/packages/docs/src/docs/pattern-add-new.md
+++ b/packages/docs/src/docs/pattern-add-new.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 70
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To add new patterns to the Node version of Pattern Lab just add new Mustache templates under the appropriate pattern type or pattern subgroup directories in `./source/_patterns`. For example, let's add a new pattern under the pattern type "molecules" and the pattern sub-type "blocks". The `./source/_patterns/molecules/blocks/` directory looks like:

--- a/packages/docs/src/docs/pattern-add-new.md
+++ b/packages/docs/src/docs/pattern-add-new.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Adding New Patterns
   key: patterns
   order: 70
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 To add new patterns to the Node version of Pattern Lab just add new Mustache templates under the appropriate pattern type or pattern subgroup directories in `./source/_patterns`. For example, let's add a new pattern under the pattern type "molecules" and the pattern sub-type "blocks". The `./source/_patterns/molecules/blocks/` directory looks like:

--- a/packages/docs/src/docs/pattern-add-new.md
+++ b/packages/docs/src/docs/pattern-add-new.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Adding New Patterns
   key: patterns
   order: 70
+sitemapPriority: '0.8'
 ---
 
 To add new patterns to the Node version of Pattern Lab just add new Mustache templates under the appropriate pattern type or pattern subgroup directories in `./source/_patterns`. For example, let's add a new pattern under the pattern type "molecules" and the pattern sub-type "blocks". The `./source/_patterns/molecules/blocks/` directory looks like:

--- a/packages/docs/src/docs/pattern-adding-annotations.md
+++ b/packages/docs/src/docs/pattern-adding-annotations.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Adding Annotations
   key: patterns
   order: 180
+sitemapPriority: '0.8'
 ---
 
 Annotations provide an easy way to add notes to elements that may appear inside patterns. Annotations can be saved as a single JSON file at `./source/_annotations/annotations.js` or as multiple Markdown files in `./source/_annotations/`. They're _not_ tied to any specific patterns. When annotations are active they are compared against every pattern using a CSS selector syntax.

--- a/packages/docs/src/docs/pattern-adding-annotations.md
+++ b/packages/docs/src/docs/pattern-adding-annotations.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Adding Annotations
   key: patterns
   order: 180
-sitemapPriority: '0.8'
 ---
 
 Annotations provide an easy way to add notes to elements that may appear inside patterns. Annotations can be saved as a single JSON file at `./source/_annotations/annotations.js` or as multiple Markdown files in `./source/_annotations/`. They're _not_ tied to any specific patterns. When annotations are active they are compared against every pattern using a CSS selector syntax.

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 110
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern documentation gives developers and designers the ability to provide context for their patterns. The documentation file consists of Markdown with YAML front matter. It should follow this format:

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Documenting Patterns
   key: patterns
   order: 110
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Pattern documentation gives developers and designers the ability to provide context for their patterns. The documentation file consists of Markdown with YAML front matter. It should follow this format:

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Documenting Patterns
   key: patterns
   order: 110
+sitemapPriority: '0.8'
 ---
 
 Pattern documentation gives developers and designers the ability to provide context for their patterns. The documentation file consists of Markdown with YAML front matter. It should follow this format:

--- a/packages/docs/src/docs/pattern-documenting.md
+++ b/packages/docs/src/docs/pattern-documenting.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Documenting Patterns
   key: patterns
   order: 110
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern documentation gives developers and designers the ability to provide context for their patterns. The documentation file consists of Markdown with YAML front matter. It should follow this format:

--- a/packages/docs/src/docs/pattern-header-footer.md
+++ b/packages/docs/src/docs/pattern-header-footer.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Modifying the Pattern Header & Footer
   key: patterns
   order: 130
+sitemapPriority: '0.8'
 ---
 
 To add your own assets like JavaScript and CSS to your patterns' header and footer you need to modify two files:

--- a/packages/docs/src/docs/pattern-header-footer.md
+++ b/packages/docs/src/docs/pattern-header-footer.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Modifying the Pattern Header & Footer
   key: patterns
   order: 130
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 To add your own assets like JavaScript and CSS to your patterns' header and footer you need to modify two files:

--- a/packages/docs/src/docs/pattern-header-footer.md
+++ b/packages/docs/src/docs/pattern-header-footer.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Modifying the Pattern Header & Footer
   key: patterns
   order: 130
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To add your own assets like JavaScript and CSS to your patterns' header and footer you need to modify two files:

--- a/packages/docs/src/docs/pattern-header-footer.md
+++ b/packages/docs/src/docs/pattern-header-footer.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 130
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To add your own assets like JavaScript and CSS to your patterns' header and footer you need to modify two files:

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Hiding Patterns in the Navigation
   key: patterns
   order: 170
+sitemapPriority: '0.8'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:
@@ -50,7 +51,7 @@ A hidden pattern can still be included in other patterns.
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for hidden patterns, add 
+To deactivate the deprecation warning for hidden patterns, add
 
 ```
 disableDeprecationWarningForHiddenPatterns: true

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 170
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Hiding Patterns in the Navigation
   key: patterns
   order: 170
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:
@@ -50,7 +52,7 @@ A hidden pattern can still be included in other patterns.
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for hidden patterns, add 
+To deactivate the deprecation warning for hidden patterns, add
 
 ```
 disableDeprecationWarningForHiddenPatterns: true

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Hiding Patterns in the Navigation
   key: patterns
   order: 170
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Hiding Patterns in the Navigation
   key: patterns
   order: 170
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:
@@ -52,7 +50,7 @@ A hidden pattern can still be included in other patterns.
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for hidden patterns, add
+To deactivate the deprecation warning for hidden patterns, add 
 
 ```
 disableDeprecationWarningForHiddenPatterns: true

--- a/packages/docs/src/docs/pattern-hiding.md
+++ b/packages/docs/src/docs/pattern-hiding.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Hiding Patterns in the Navigation
   key: patterns
   order: 170
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Removing a pattern from Pattern Lab's drop-down navigation and style guide is accomplished by setting the `hidden` frontmatter key on any pattern's companion `.md` file. For example, we may have a Google Map-based pattern that we don't need for a particular project. The path might look like:

--- a/packages/docs/src/docs/pattern-including.md
+++ b/packages/docs/src/docs/pattern-including.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 90
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To include one pattern within another, for example to create a molecule from several atoms, you can either use:

--- a/packages/docs/src/docs/pattern-including.md
+++ b/packages/docs/src/docs/pattern-including.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Including Patterns
   key: patterns
   order: 90
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 To include one pattern within another, for example to create a molecule from several atoms, you can either use:

--- a/packages/docs/src/docs/pattern-including.md
+++ b/packages/docs/src/docs/pattern-including.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Including Patterns
   key: patterns
   order: 90
+sitemapPriority: '0.8'
 ---
 
 To include one pattern within another, for example to create a molecule from several atoms, you can either use:

--- a/packages/docs/src/docs/pattern-including.md
+++ b/packages/docs/src/docs/pattern-including.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Including Patterns
   key: patterns
   order: 90
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 To include one pattern within another, for example to create a molecule from several atoms, you can either use:

--- a/packages/docs/src/docs/pattern-linking.md
+++ b/packages/docs/src/docs/pattern-linking.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Pattern Lab's Special Query String Variables
   key: patterns
   order: 100
+sitemapPriority: '0.8'
 ---
 
 Pattern Lab comes with support for a number of special query string variables to help you share patterns with clients. These query string variables include ways to link to patterns, set the Pattern Lab viewport to a specific width, open various views as well as start Hay and disco modes on page load. There are lots of options:

--- a/packages/docs/src/docs/pattern-linking.md
+++ b/packages/docs/src/docs/pattern-linking.md
@@ -7,7 +7,6 @@ eleventyNavigation:
   title: Pattern Lab's Special Query String Variables
   key: patterns
   order: 100
-sitemapPriority: '0.8'
 ---
 
 Pattern Lab comes with support for a number of special query string variables to help you share patterns with clients. These query string variables include ways to link to patterns, set the Pattern Lab viewport to a specific width, open various views as well as start Hay and disco modes on page load. There are lots of options:

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Managing Pattern Assets
   key: patterns
   order: 120
+sitemapPriority: '0.8'
 ---
 
 Assets for patterns - including JavaScript, CSS, and images - should be stored and edited in the `./source/` directory. Pattern Lab will move these assets to the `./public/` directory for you when you generate your site or when you watch the `./source/` directory for changes. _You can name and organize your assets however you like._ If you would like to use `./source/stylesheets/` to store your styles instead of `./source/css/` you can do that. The structure will be maintained when they're moved to the `./public/` directory.

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Managing Pattern Assets
   key: patterns
   order: 120
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Assets for patterns - including JavaScript, CSS, and images - should be stored and edited in the `./source/` directory. Pattern Lab will move these assets to the `./public/` directory for you when you generate your site or when you watch the `./source/` directory for changes. _You can name and organize your assets however you like._ If you would like to use `./source/stylesheets/` to store your styles instead of `./source/css/` you can do that. The structure will be maintained when they're moved to the `./public/` directory.

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 120
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Assets for patterns - including JavaScript, CSS, and images - should be stored and edited in the `./source/` directory. Pattern Lab will move these assets to the `./public/` directory for you when you generate your site or when you watch the `./source/` directory for changes. _You can name and organize your assets however you like._ If you would like to use `./source/stylesheets/` to store your styles instead of `./source/css/` you can do that. The structure will be maintained when they're moved to the `./public/` directory.

--- a/packages/docs/src/docs/pattern-managing-assets.md
+++ b/packages/docs/src/docs/pattern-managing-assets.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Managing Pattern Assets
   key: patterns
   order: 120
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Assets for patterns - including JavaScript, CSS, and images - should be stored and edited in the `./source/` directory. Pattern Lab will move these assets to the `./public/` directory for you when you generate your site or when you watch the `./source/` directory for changes. _You can name and organize your assets however you like._ If you would like to use `./source/stylesheets/` to store your styles instead of `./source/css/` you can do that. The structure will be maintained when they're moved to the `./public/` directory.

--- a/packages/docs/src/docs/pattern-organization.md
+++ b/packages/docs/src/docs/pattern-organization.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Overview of Patterns
   key: patterns
   order: 10
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/template-language-and-patternengines/).

--- a/packages/docs/src/docs/pattern-organization.md
+++ b/packages/docs/src/docs/pattern-organization.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Overview of Patterns
   key: patterns
   order: 10
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/template-language-and-patternengines/).

--- a/packages/docs/src/docs/pattern-organization.md
+++ b/packages/docs/src/docs/pattern-organization.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 10
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/template-language-and-patternengines/).

--- a/packages/docs/src/docs/pattern-organization.md
+++ b/packages/docs/src/docs/pattern-organization.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Overview of Patterns
   key: patterns
   order: 10
+sitemapPriority: '0.8'
 ---
 
 Patterns can be found in `./source/_patterns/`. Patterns must be written in the template languages supported by Pattern Lab's PatternEngines. For Node there are [several more PatternEngines to choose from](/docs/template-language-and-patternengines/).

--- a/packages/docs/src/docs/pattern-parameters.md
+++ b/packages/docs/src/docs/pattern-parameters.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Using Pattern Parameters
   key: patterns
   order: 150
+sitemapPriority: '0.8'
 ---
 
 **Important:** Pattern parameters are supported by the Node Mustache PatternEngines. Other template languages provide better solutions to this problem.

--- a/packages/docs/src/docs/pattern-parameters.md
+++ b/packages/docs/src/docs/pattern-parameters.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 150
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 **Important:** Pattern parameters are supported by the Node Mustache PatternEngines. Other template languages provide better solutions to this problem.

--- a/packages/docs/src/docs/pattern-parameters.md
+++ b/packages/docs/src/docs/pattern-parameters.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Using Pattern Parameters
   key: patterns
   order: 150
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 **Important:** Pattern parameters are supported by the Node Mustache PatternEngines. Other template languages provide better solutions to this problem.

--- a/packages/docs/src/docs/pattern-parameters.md
+++ b/packages/docs/src/docs/pattern-parameters.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Using Pattern Parameters
   key: patterns
   order: 150
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 **Important:** Pattern parameters are supported by the Node Mustache PatternEngines. Other template languages provide better solutions to this problem.

--- a/packages/docs/src/docs/pattern-pseudo-patterns.md
+++ b/packages/docs/src/docs/pattern-pseudo-patterns.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Using Pseudo-Patterns
   key: patterns
   order: 140
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pseudo-patterns give developers and designers the ability to quickly build multiple unique variants of an existing pattern. This feature is especially useful when developing template- and page-style patterns or showing the states of other patterns.

--- a/packages/docs/src/docs/pattern-pseudo-patterns.md
+++ b/packages/docs/src/docs/pattern-pseudo-patterns.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 140
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pseudo-patterns give developers and designers the ability to quickly build multiple unique variants of an existing pattern. This feature is especially useful when developing template- and page-style patterns or showing the states of other patterns.

--- a/packages/docs/src/docs/pattern-pseudo-patterns.md
+++ b/packages/docs/src/docs/pattern-pseudo-patterns.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Using Pseudo-Patterns
   key: patterns
   order: 140
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Pseudo-patterns give developers and designers the ability to quickly build multiple unique variants of an existing pattern. This feature is especially useful when developing template- and page-style patterns or showing the states of other patterns.

--- a/packages/docs/src/docs/pattern-pseudo-patterns.md
+++ b/packages/docs/src/docs/pattern-pseudo-patterns.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Using Pseudo-Patterns
   key: patterns
   order: 140
+sitemapPriority: '0.8'
 ---
 
 Pseudo-patterns give developers and designers the ability to quickly build multiple unique variants of an existing pattern. This feature is especially useful when developing template- and page-style patterns or showing the states of other patterns.

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 80
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Reorganizing Patterns
   key: patterns
   order: 80
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.
@@ -111,7 +109,7 @@ order: 1
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for ordering patterns, add
+To deactivate the deprecation warning for ordering patterns, add 
 
 ```
 disableDeprecationWarningForOrderPatterns: true

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Reorganizing Patterns
   key: patterns
   order: 80
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Reorganizing Patterns
   key: patterns
   order: 80
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Reorganizing Patterns
   key: patterns
   order: 80
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.
@@ -109,7 +111,7 @@ order: 1
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for ordering patterns, add 
+To deactivate the deprecation warning for ordering patterns, add
 
 ```
 disableDeprecationWarningForOrderPatterns: true

--- a/packages/docs/src/docs/pattern-reorganizing.md
+++ b/packages/docs/src/docs/pattern-reorganizing.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Reorganizing Patterns
   key: patterns
   order: 80
+sitemapPriority: '0.8'
 ---
 
 By default, the Node version of Pattern Lab organizes pattern groups, pattern subgroups, and patterns alphabetically when displaying them in the drop-down navigation, pattern subgroup "view all" pages, and the "all" style guide. This may not meet your needs. You can re-order pattern groups, pattern subgroups, and patterns by prefixing them with two-digit numbers.
@@ -109,7 +110,7 @@ order: 1
 
 ## Deactivate deprecation warning
 
-To deactivate the deprecation warning for ordering patterns, add 
+To deactivate the deprecation warning for ordering patterns, add
 
 ```
 disableDeprecationWarningForOrderPatterns: true

--- a/packages/docs/src/docs/pattern-states.md
+++ b/packages/docs/src/docs/pattern-states.md
@@ -7,6 +7,8 @@ eleventyNavigation:
   title: Using Pattern States
   key: patterns
   order: 160
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern states provide your team and client a simple visual of the current state of patterns in Pattern Lab. Pattern states can track progress of a pattern from development, through client review, to completion or they can be used to give certain patterns specific classes. It's important to note that the state of a pattern can be influenced by its pattern partials.

--- a/packages/docs/src/docs/pattern-states.md
+++ b/packages/docs/src/docs/pattern-states.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   key: patterns
   order: 160
 sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
 ---
 
 Pattern states provide your team and client a simple visual of the current state of patterns in Pattern Lab. Pattern states can track progress of a pattern from development, through client review, to completion or they can be used to give certain patterns specific classes. It's important to note that the state of a pattern can be influenced by its pattern partials.

--- a/packages/docs/src/docs/pattern-states.md
+++ b/packages/docs/src/docs/pattern-states.md
@@ -7,8 +7,6 @@ eleventyNavigation:
   title: Using Pattern States
   key: patterns
   order: 160
-sitemapPriority: '0.8'
-sitemapChangefreq: 'monthly'
 ---
 
 Pattern states provide your team and client a simple visual of the current state of patterns in Pattern Lab. Pattern states can track progress of a pattern from development, through client review, to completion or they can be used to give certain patterns specific classes. It's important to note that the state of a pattern can be influenced by its pattern partials.

--- a/packages/docs/src/docs/pattern-states.md
+++ b/packages/docs/src/docs/pattern-states.md
@@ -7,6 +7,7 @@ eleventyNavigation:
   title: Using Pattern States
   key: patterns
   order: 160
+sitemapPriority: '0.8'
 ---
 
 Pattern states provide your team and client a simple visual of the current state of patterns in Pattern Lab. Pattern states can track progress of a pattern from development, through client review, to completion or they can be used to give certain patterns specific classes. It's important to note that the state of a pattern can be influenced by its pattern partials.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -7,6 +7,7 @@ tags:
 eleventyNavigation:
   key: php-compile
   order: 300
+sitemapChangefreq: 'never'
 ---
 
 The PHP version of Pattern Lab is being deprecated in favor of a new unified Pattern Lab core. The PHP docs for this topic can be viewed here.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: php-compile
 tags:
   - demo-content
@@ -7,6 +8,7 @@ tags:
 eleventyNavigation:
   key: php-compile
   order: 300
+sitemapChangefreq: 'never'
 ---
 
 The PHP version of Pattern Lab is being deprecated in favor of a new unified Pattern Lab core. The PHP docs for this topic can be viewed here.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: php-compile
 tags:
   - demo-content
@@ -9,6 +8,7 @@ eleventyNavigation:
   key: php-compile
   order: 300
 sitemapChangefreq: 'never'
+sitemapIgnore: true
 ---
 
 The PHP version of Pattern Lab is being deprecated in favor of a new unified Pattern Lab core. The PHP docs for this topic can be viewed here.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: php-compile
 tags:
   - demo-content
@@ -8,7 +7,6 @@ tags:
 eleventyNavigation:
   key: php-compile
   order: 300
-sitemapChangefreq: 'never'
 ---
 
 The PHP version of Pattern Lab is being deprecated in favor of a new unified Pattern Lab core. The PHP docs for this topic can be viewed here.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -7,7 +7,6 @@ tags:
 eleventyNavigation:
   key: php-compile
   order: 300
-sitemapChangefreq: 'never'
 ---
 
 The PHP version of Pattern Lab is being deprecated in favor of a new unified Pattern Lab core. The PHP docs for this topic can be viewed here.

--- a/packages/docs/src/docs/php-compile.md
+++ b/packages/docs/src/docs/php-compile.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: php-compile
 tags:
   - demo-content

--- a/packages/docs/src/feed.njk
+++ b/packages/docs/src/feed.njk
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 permalink: '/feed.xml'
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/packages/docs/src/feed.njk
+++ b/packages/docs/src/feed.njk
@@ -1,6 +1,6 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: '/feed.xml'
+sitemapIgnore: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/packages/docs/src/feed.njk
+++ b/packages/docs/src/feed.njk
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: '/feed.xml'
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -1,4 +1,7 @@
 ---
 layout: home
 title: Create atomic design systems with Pattern Lab
+sitemapChangefreq: 'yearly'
+sitemapPriority: '1.0'
+sitemapChangefreq: 'monthly'
 ---

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -1,7 +1,4 @@
 ---
 layout: home
 title: Create atomic design systems with Pattern Lab
-sitemapChangefreq: 'yearly'
-sitemapPriority: '1.0'
-sitemapChangefreq: 'monthly'
 ---

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -1,4 +1,5 @@
 ---
 layout: home
 title: Create atomic design systems with Pattern Lab
+sitemapPriority: '1.0'
 ---

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -2,4 +2,5 @@
 layout: home
 title: Create atomic design systems with Pattern Lab
 sitemapPriority: '1.0'
+sitemapChangefreq: 'monthly'
 ---

--- a/packages/docs/src/posts/pattern-lab-website-redesign.md
+++ b/packages/docs/src/posts/pattern-lab-website-redesign.md
@@ -5,6 +5,7 @@ date: '2020-02-17'
 tags:
   - blog
 url: '/posts/pattern-lab-website-redesign'
+sitemapChangefreq: 'never'
 ---
 
 We're pleased to announce the Pattern Lab website is undergoing a much-needed facelift!

--- a/packages/docs/src/posts/pattern-lab-website-redesign.md
+++ b/packages/docs/src/posts/pattern-lab-website-redesign.md
@@ -5,7 +5,6 @@ date: '2020-02-17'
 tags:
   - blog
 url: '/posts/pattern-lab-website-redesign'
-sitemapChangefreq: 'never'
 ---
 
 We're pleased to announce the Pattern Lab website is undergoing a much-needed facelift!

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/page-base.njk
 title: Resources
+sitemapPriority: '0.8'
 ---
 
 ## Style guides and atomic design

--- a/packages/docs/src/resources.md
+++ b/packages/docs/src/resources.md
@@ -1,7 +1,6 @@
 ---
 layout: layouts/page-base.njk
 title: Resources
-sitemapPriority: '0.8'
 ---
 
 ## Style guides and atomic design

--- a/packages/docs/src/robots.njk
+++ b/packages/docs/src/robots.njk
@@ -1,0 +1,7 @@
+---
+eleventyExcludeFromCollections: true
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+Sitemap: {{ site.url }}/sitemap.xml

--- a/packages/docs/src/robots.njk
+++ b/packages/docs/src/robots.njk
@@ -1,6 +1,6 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: /robots.txt
+sitemapIgnore: true
 ---
 User-agent: *
 Allow: /

--- a/packages/docs/src/sitemap.njk
+++ b/packages/docs/src/sitemap.njk
@@ -1,15 +1,17 @@
 ---
-eleventyExcludeFromCollections: true
 permalink: /sitemap.xml
+sitemapIgnore: true
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {% for item in collections.all %}
-  <url>
-    <loc>{{ site.url }}{{ item.url }}</loc>
-    <lastmod>{{ item.date | w3DateFilter()}}</lastmod>
-    <changefreq>{{ item.data.sitemapChangefreq | default("yearly") }}</changefreq>
-    <priority>{{ item.data.sitemapPriority | default(0.7) }}</priority>
-  </url>
+{% if not item.data.sitemapIgnore %}
+    <url>
+      <loc>{{ site.url }}{{ item.url }}</loc>
+      <lastmod>{{ item.date | w3DateFilter()}}</lastmod>
+      <changefreq>{{ item.data.sitemapChangefreq | default("yearly") }}</changefreq>
+      <priority>{{ item.data.sitemapPriority | default(0.7) }}</priority>
+    </url>
+{% endif %}
 {% endfor %}
 </urlset>

--- a/packages/docs/src/sitemap.njk
+++ b/packages/docs/src/sitemap.njk
@@ -1,0 +1,15 @@
+---
+eleventyExcludeFromCollections: true
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in collections.all %}
+  <url>
+    <loc>{{ site.url }}{{ item.url }}</loc>
+    <lastmod>{{ item.date | w3DateFilter()}}</lastmod>
+    <changefreq>{{ item.data.sitemapChangefreq | default("yearly") }}</changefreq>
+    <priority>{{ item.data.sitemapPriority | default(0.7) }}</priority>
+  </url>
+{% endfor %}
+</urlset>

--- a/packages/docs/src/styleguide.njk
+++ b/packages/docs/src/styleguide.njk
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 title: 'Styleguide'
 permalink: /styleguide/
 ---

--- a/packages/docs/src/styleguide.njk
+++ b/packages/docs/src/styleguide.njk
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: 'Styleguide'
 permalink: /styleguide/
 ---

--- a/packages/docs/src/styleguide.njk
+++ b/packages/docs/src/styleguide.njk
@@ -1,7 +1,7 @@
 ---
-eleventyExcludeFromCollections: true
 title: 'Styleguide'
 permalink: /styleguide/
+sitemapIgnore: true
 ---
 
 {% extends 'layouts/base.njk' %}

--- a/packages/docs/src/styleguide.njk
+++ b/packages/docs/src/styleguide.njk
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 title: 'Styleguide'
 permalink: /styleguide/
 ---
@@ -22,7 +23,7 @@ permalink: /styleguide/
     }
 
     .props dt {
-      font-weight: 600;  
+      font-weight: 600;
     }
 
     .props dd + dt {

--- a/packages/docs/src/support.md
+++ b/packages/docs/src/support.md
@@ -1,7 +1,6 @@
 ---
 layout: layouts/post.njk
 title: Pattern Lab Support
-sitemapPriority: '0.8'
 ---
 
 ## GitHub

--- a/packages/docs/src/support.md
+++ b/packages/docs/src/support.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/post.njk
 title: Pattern Lab Support
+sitemapPriority: '0.8'
 ---
 
 ## GitHub

--- a/packages/docs/src/tags.njk
+++ b/packages/docs/src/tags.njk
@@ -13,6 +13,7 @@ pagination:
     - postFeed
   addAllPagesToCollections: true
 permalink: /tags/{{ tag }}/
+sitemapIgnore: true
 ---
 
 {% extends 'layouts/base.njk' %}

--- a/packages/docs/src/updates.md
+++ b/packages/docs/src/updates.md
@@ -1,5 +1,4 @@
 ---
-eleventyExcludeFromCollections: true
 layout: layouts/blog.njk
 title: Pattern Lab Updates
 description: The latest news about the Pattern Lab project

--- a/packages/docs/src/updates.md
+++ b/packages/docs/src/updates.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 layout: layouts/blog.njk
 title: Pattern Lab Updates
 description: The latest news about the Pattern Lab project

--- a/packages/docs/src/updates.md
+++ b/packages/docs/src/updates.md
@@ -1,6 +1,6 @@
 ---
-eleventyExcludeFromCollections: true
 layout: layouts/blog.njk
 title: Pattern Lab Updates
 description: The latest news about the Pattern Lab project
+sitemapIgnore: true
 ---


### PR DESCRIPTION
### Summary of changes:

Adding an auto-generated `sitemap.xml` to the root of the domain https://patternlab.io/

#### Outstanding issues
- prevent the generation of the https://patternlab.io/tags/* pages
- prevent the generation of the https://patternlab.io/demos/* pages