### PR TITLE
chore: adding start script #1343

### DIFF
--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -1,0 +1,27 @@
+---
+title: Running Pattern Lab
+tags:
+  - docs
+category: getting-started
+eleventyNavigation:
+  title: Running Pattern Lab
+  key: getting-started
+  order: 1
+sitemapPriority: '0.8'
+sitemapChangefreq: 'monthly'
+---
+
+## Running Pattern Lab
+
+It's as easy as running the following command:
+
+```
+npm run start
+```
+
+This will start the system and open the URL it's running on within your browser.
+Relevant information regarding and step and possible errors are being logged to the console so it's recommended to watch out for any problems possibly occuring with your installation or any of the content or data you're setting up.
+
+### Problems and errors after restructuring files and folders
+
+If you're doing bigger changes especially to the file and folder structure and recognize some errors on the console like e.g. `TypeError: Cannot read property 'render' of undefined` or `Error building BuildFooterHTML`, it's recommended to stop Pattern Lab, delete the cache file `dependencyGraph.json` within the projects root and start Pattern Lab again, as these changes might conflict with the existing cache structures.

--- a/packages/edition-node/package.json
+++ b/packages/edition-node/package.json
@@ -23,7 +23,8 @@
     "pl:help": "patternlab --help",
     "pl:install": "patternlab install --config ./patternlab-config.json",
     "pl:serve": "patternlab serve --config ./patternlab-config.json",
-    "pl:version": "patternlab --version"
+    "pl:version": "patternlab --version",
+    "start": "npm run pl:serve"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Closes #1343

### Summary of changes:
Adding a `start` script which was included if you're using `twig`, but isn't in case of `handlebars`.

While searching for a good place to especially mention the suggestions out of #1350 to delete the cache file on problems coming up on the console, I've recognized that we don't have a documentation page regarding running patternlab itself. Even though that this might be a simple one, it's probably still worth to mention.