### PR TITLE
fix(docs): use "UIKits" instead of "StyleguideKits"

### DIFF
--- a/packages/docs/src/docs/advanced-ecosystem-overview.md
+++ b/packages/docs/src/docs/advanced-ecosystem-overview.md
@@ -38,9 +38,9 @@ Importing a starterkit is only a few keystrokes away after installation.
 
 [Learn more about Starterkits](/docs/starterkits/)
 
-### StyleguideKits
+### UIKits
 
-StyleguideKits are the front-end of Pattern Lab. We call this “The Viewer.” StyleguideKits allow agencies and organizations to develop custom, branded Pattern Lab UIs to show off their patterns.
+UIKits are the front-end of Pattern Lab. We call this “The Viewer.” UIKits allow agencies and organizations to develop custom, branded Pattern Lab UIs to show off their patterns.
 
 ### PatternEngines
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Closes –

Summary of changes:

Align the terminology of custom pattern lab UIs with what is used in the configuration currently.
The documentation now uses "UIKits" to align with the "uikits" property of the pattern lab
configuration.
