### PR TITLE
fix(initialize): removing no-emit-webpack-plugin dependency #1348

### DIFF
--- a/packages/uikit-workshop/package.json
+++ b/packages/uikit-workshop/package.json
@@ -78,7 +78,6 @@
     "lit-html": "^1.1.2",
     "mini-css-extract-plugin": "^0.8.0",
     "mousetrap": "^1.6.5",
-    "no-emit-webpack-plugin": "^1.0.0",
     "node-sass": "^6.0.0",
     "node-sass-selector-importer": "^5.2.0",
     "postcss-loader": "^3.0.0",

--- a/packages/uikit-workshop/webpack.config.js
+++ b/packages/uikit-workshop/webpack.config.js
@@ -2,7 +2,6 @@
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin-patch');
 const TerserPlugin = require('terser-webpack-plugin');
-const NoEmitPlugin = require('no-emit-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -255,11 +254,7 @@ module.exports = function (apiConfig) {
             ]
           : [],
       },
-      plugins: [
-        new WebpackBar(),
-        new CopyPlugin(config.copy),
-        new NoEmitPlugin(['css/pattern-lab.js']),
-      ],
+      plugins: [new WebpackBar(), new CopyPlugin(config.copy)],
     };
 
     webpackConfig.plugins.push(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11614,13 +11614,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-no-emit-webpack-plugin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/no-emit-webpack-plugin/-/no-emit-webpack-plugin-1.0.0.tgz#b9a6e598bd01f8c35eacea030c89176692a30d16"
-  integrity sha512-0NW3QzACRnSbfY8r1VEwFFmkbbAMVVP3ArOpmfldTFYM8v9uLEktxRe5MKwUbNql21b5QPATdaTrcQTxVCMQpg==
-  dependencies:
-    schema-utils "^0.4.3"
-
 node-emoji@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
@@ -14635,14 +14628,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-schema-utils@^0.4.3:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The outdated version of [no-emit-webpack-plugin](https://www.npmjs.com/package/no-emit-webpack-plugin) results in a freeze during installation.

Closes #1348

### Summary of changes:
I've removed that plugin, that got introduced by https://github.com/pattern-lab/patternlab-node/pull/920/, but doesn't seem to actually get used, but that older version causes the problem described above.
And I‘ve identified this package to be the cause while installing `@pattern-lab/edition-node` directly and the installation got stuck exactly at that dependency.