### PR TITLE
chore(docs): mentioning to delete the cache file

### DIFF
--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -77,8 +77,10 @@ In the Node version of Pattern Lab you can modify the following configuration op
 }
 ```
 
+## Problems after changing the structure
+
+If you're doing bigger changes especially to the file and folder structure and recognize some errors on the console like e.g. `TypeError: Cannot read property 'render' of undefined` or `Error building BuildFooterHTML`, it's recommended to stop patternlab, delete the cache file `dependencyGraph.json` within the projects root and start patternlab again, as these changes might conflict with the existing cache structures.
+
 ## Watching for Source File Changes
 
 Manually generating the Pattern Lab website after each change can be cumbersome. The Node version of Pattern Lab comes with the ability to watch files in the `./source/` directory for changes and re-generate the site automatically. The Pattern Lab website can also be automatically reloaded.
-
-If you're doing bigger changes especially to the file and folder structure, it's recommended to stop patternlab, delete the cache file `dependencyGraph.json` within the projects root and start patternlab again, as these changes might conflict with the existing cache structures.

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -79,7 +79,7 @@ In the Node version of Pattern Lab you can modify the following configuration op
 
 ## Problems after changing the structure
 
-If you're doing bigger changes especially to the file and folder structure and recognize some errors on the console like e.g. `TypeError: Cannot read property 'render' of undefined` or `Error building BuildFooterHTML`, it's recommended to stop patternlab, delete the cache file `dependencyGraph.json` within the projects root and start patternlab again, as these changes might conflict with the existing cache structures.
+If you're doing bigger changes, especially to the file and folder structure, and recognize some errors on the console like, e.g. `TypeError: Cannot read property 'render' of undefined` or `Error building BuildFooterHTML`, it's recommended to stop pattern lab, delete the cache file `dependencyGraph.json` within the root of the project and start pattern lab again, as these changes might conflict with the existing cache structures.
 
 ## Watching for Source File Changes
 

--- a/packages/docs/src/docs/editing-source-files.md
+++ b/packages/docs/src/docs/editing-source-files.md
@@ -79,4 +79,6 @@ In the Node version of Pattern Lab you can modify the following configuration op
 
 ## Watching for Source File Changes
 
-Manually generating the Pattern Lab website after each change can be cumbersome. The Node version of Pattern Lab comes with the ability to watch files in the `./source/` directory for changes and re-generate the site automatically. The Pattern Lab website can also be automatically reloaded..
+Manually generating the Pattern Lab website after each change can be cumbersome. The Node version of Pattern Lab comes with the ability to watch files in the `./source/` directory for changes and re-generate the site automatically. The Pattern Lab website can also be automatically reloaded.
+
+If you're doing bigger changes especially to the file and folder structure, it's recommended to stop patternlab, delete the cache file `dependencyGraph.json` within the projects root and start patternlab again, as these changes might conflict with the existing cache structures.


### PR DESCRIPTION
### Summary of changes:
chore(docs): mentioning to delete the cache file `dependencyGraph.json` because of errors on the console
