### PR TITLE
refactor: preventing problem on nested PL output

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -291,7 +291,7 @@ Available values are:
   "logo": {
     "text": "Pattern Lab",
     "altText": "Pattern Lab Logo",
-    "url": "/",
+    "url": "./",
     "srcLight": "styleguide/images/pattern-lab-logo--on-light.svg",
     "srcDark": "styleguide/images/pattern-lab-logo--on-dark.svg",
     "width": "187",

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-header/pl-header.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-header/pl-header.js
@@ -116,7 +116,7 @@ class Header extends BaseLitComponent {
                 url="${window.config?.theme?.logo?.url === '' ||
                 window.config?.theme?.logo?.url === 'none'
                   ? ''
-                  : window.config?.theme?.logo?.url || '/'}"
+                  : window.config?.theme?.logo?.url || './'}"
                 alt-text="${window.config?.theme?.logo?.altText || ''}"
                 theme="${this.themeMode}"
                 width="${ifDefined(window.config?.theme?.logo?.width)}"


### PR DESCRIPTION
### Summary of changes:
On a patternlab installation nested in subfolder(s), the main link on the logo currently points to the top level root. By changing the default from `"/"` to `"./"` we could support both nested installations as well as the ones directly hosted in the root of the URL.