### PR TITLE
feat: added https description to the docs

### DIFF
--- a/packages/core/src/lib/server.js
+++ b/packages/core/src/lib/server.js
@@ -87,7 +87,9 @@ const server = (patternlab) => {
           setTimeout(() => {
             try {
               liveServer.start(liveServerConfig);
-              resolveMsg = `Pattern Lab is being served from http://127.0.0.1:${liveServerConfig.port}`;
+              resolveMsg = `Pattern Lab is being served from ${
+                liveServerConfig.https ? 'https' : 'http'
+              }://127.0.0.1:${liveServerConfig.port}`;
               logger.info(resolveMsg);
             } catch (e) {
               const err = `Pattern Lab serve failed to start: ${e}`;

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -237,7 +237,7 @@ Sets [live-server options](https://github.com/pattern-lab/live-server#usage-from
 | mount         | [['/components', './node_modules']]    | Mount a directory to a route.                                                                                                                                                                                    |
 | logLevel      | 2                                      | 0 = errors only, 1 = some, 2 = lots                                                                                                                                                                              |
 | middleware    | [function(req, res, next) { next(); }] | Takes an array of Connect-compatible middleware that are injected into the server middleware stack |
-| https         | 'ssl/ssl.js'                           | adding the path to a configuration module for HTTPS dev servers, see detailed explanation on the <a href="/docs/running-pattern-lab/#heading-running-localhost-via-https">`running patternlab` page</a> |
+| https         | 'ssl/ssl.js'                           | adding the path to a configuration module for HTTPS dev servers, see detailed explanation on the[`running patternlab` page](/docs/running-pattern-lab/#heading-running-localhost-via-https) |
 
 **default**:
 

--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -236,7 +236,8 @@ Sets [live-server options](https://github.com/pattern-lab/live-server#usage-from
 | wait          | 100                                    | Waits for all changes, before reloading. Defaults to 0 sec.                                                                                                                                                      |
 | mount         | [['/components', './node_modules']]    | Mount a directory to a route.                                                                                                                                                                                    |
 | logLevel      | 2                                      | 0 = errors only, 1 = some, 2 = lots                                                                                                                                                                              |
-| middleware    | [function(req, res, next) { next(); }] | Takes an array of Connect-compatible middleware that are injected into the server middleware stack                                                                                                               |
+| middleware    | [function(req, res, next) { next(); }] | Takes an array of Connect-compatible middleware that are injected into the server middleware stack |
+| https         | 'ssl/ssl.js'                           | adding the path to a configuration module for HTTPS dev servers, see detailed explanation on the <a href="/docs/running-pattern-lab/#heading-running-localhost-via-https">`running patternlab` page</a> |
 
 **default**:
 

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -37,7 +37,7 @@ Achieving this is a three-step process:
 
 #### Generate a self-signed SSL certificate
 
-First create a folder like e.g. `ssl` in the root of your project.
+First, create a folder like, e.g., `ssl` at the root of your project.
 
 Then run the following command in your terminal:
 

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -68,7 +68,7 @@ According to the [`live-server` documentation](https://github.com/pattern-lab/li
 
 > In order to enable HTTPS support, you'll need to create a configuration module.
 
-In our case, you could e.g. create a file called `ssl.js` in the `ssl` folder with the following contents:
+In our case, you could, e.g., create a file called `ssl.js` in the `ssl` folder with the following contents:
 
 ```js
 var fs = require("fs");

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -87,4 +87,4 @@ Finally, you'll have to add this as a configuration module to the pattern lab `s
 },
 ```
 
-Et voilà, after starting the process of serving patternlab the next time it'll open as a secured page.
+Et voilà, after starting the process of serving pattern lab the next time, it'll open as a secured page.

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -79,7 +79,7 @@ module.exports = {
 };
 ```
 
-Finally you'll have to add this as configuration module to the patternlab `serverOptions` within the `patternlab-config.json` file:
+Finally, you'll have to add this as a configuration module to the pattern lab `serverOptions` within the `patternlab-config.json` file:
 ```json
 "serverOptions": {
   ...

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -25,3 +25,66 @@ Relevant information regarding and step and possible errors are being logged to 
 ### Problems and errors after restructuring files and folders
 
 If you're doing bigger changes especially to the file and folder structure and recognize some errors on the console like e.g. `TypeError: Cannot read property 'render' of undefined` or `Error building BuildFooterHTML`, it's recommended to stop Pattern Lab, delete the cache file `dependencyGraph.json` within the projects root and start Pattern Lab again, as these changes might conflict with the existing cache structures.
+
+### Running localhost via HTTPS
+
+There might be use cases in which you'd like to let your [localhost dev server run via HTTPS instead of HTTP](https://github.com/pattern-lab/live-server#https), like e.g. when consuming from other secure contexts to prevent browser errors or problems.
+
+Achieving this is a three step process:
+- generate a self-signed SSL certificate
+- add it to the trusted certificates
+- configure the certificates for `live-server`
+
+#### Generate a self-signed SSL certificate
+
+First create a folder like e.g. `ssl` in the root of your project.
+
+Then run the following command in your terminal:
+
+```
+openssl req -x509 -nodes -out ssl/localhost.crt \
+  -keyout ssl/localhost.key \
+  -newkey rsa:2048 -sha256 \
+  -subj '/CN=localhost' -extensions EXT \
+  -config <( \
+   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
+```
+
+This has been adapted from <https://stackoverflow.com/a/56074120> according to the [`Let's encrypt` instructions](https://letsencrypt.org/docs/certificates-for-localhost/); additionally DigitalOcean provices some further explanations in [a tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04).
+
+#### Add the certificate to the trusted certificates
+
+A [stack overflow entry](https://stackoverflow.com/a/56074120) as well mentions to use the following command to add the certificate to the trusted certificates, as [suggested on a blog](https://derflounder.wordpress.com/2011/03/13/adding-new-trusted-root-certificates-to-system-keychain/):
+
+```
+sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" "ssl/localhost.crt"
+```
+
+You could as well skip this step and accept the certificate after opening the secured patternlab in your browser for the first time, as described in step 5 of the [DigitalOcean tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04#step-5-test-encryption).
+
+#### Configure the certificates for `live-server`
+
+According to the [`live-server` documentation](https://github.com/pattern-lab/live-server#https) you'll then add those certificates to the local dev server:
+
+> In order to enable HTTPS support, you'll need to create a configuration module.
+
+In our case, you could e.g. create a file called `ssl.js` in the `ssl` folder with the following contents:
+
+```js
+var fs = require("fs");
+
+module.exports = {
+	cert: fs.readFileSync(__dirname + "/localhost.crt"),
+	key: fs.readFileSync(__dirname + "/localhost.key")
+};
+```
+
+Finally you'll have to add this as configuration module to the patternlab `serverOptions` within the `patternlab-config.json` file:
+```json
+"serverOptions": {
+  ...
+  "https": "ssl/ssl.js"
+},
+```
+
+Et voilà, after starting the processing of serving patternlab the next time it'll open as a secured page.

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -64,7 +64,7 @@ You could as well skip this step and accept the certificate after opening the se
 
 #### Configure the certificates for `live-server`
 
-According to the [`live-server` documentation](https://github.com/pattern-lab/live-server#https) you'll then add those certificates to the local dev server:
+According to the [`live-server` documentation](https://github.com/pattern-lab/live-server#https), you'll then add those certificates to the local dev server:
 
 > In order to enable HTTPS support, you'll need to create a configuration module.
 

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -54,7 +54,7 @@ This has been adapted from <https://stackoverflow.com/a/56074120> according to t
 
 #### Add the certificate to the trusted certificates
 
-A [stack overflow entry](https://stackoverflow.com/a/56074120) as well mentions to use the following command to add the certificate to the trusted certificates, as [suggested on a blog](https://derflounder.wordpress.com/2011/03/13/adding-new-trusted-root-certificates-to-system-keychain/):
+A [stack overflow entry](https://stackoverflow.com/a/56074120) as well mentions using the following command to add the certificate to the trusted certificates, as [suggested on a blog](https://derflounder.wordpress.com/2011/03/13/adding-new-trusted-root-certificates-to-system-keychain/):
 
 ```
 sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" "ssl/localhost.crt"

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -87,4 +87,4 @@ Finally you'll have to add this as configuration module to the patternlab `serve
 },
 ```
 
-Et voilà, after starting the processing of serving patternlab the next time it'll open as a secured page.
+Et voilà, after starting the process of serving patternlab the next time it'll open as a secured page.

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -30,7 +30,7 @@ If you're doing bigger changes especially to the file and folder structure and r
 
 There might be use cases in which you'd like to let your [localhost dev server run via HTTPS instead of HTTP](https://github.com/pattern-lab/live-server#https), like e.g. when consuming from other secure contexts to prevent browser errors or problems.
 
-Achieving this is a three step process:
+Achieving this is a three-step process:
 - generate a self-signed SSL certificate
 - add it to the trusted certificates
 - configure the certificates for `live-server`

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -66,7 +66,7 @@ You could as well skip this step and accept the certificate after opening the se
 
 According to the [`live-server` documentation](https://github.com/pattern-lab/live-server#https), you'll then add those certificates to the local dev server:
 
-> In order to enable HTTPS support, you'll need to create a configuration module.
+> To enable HTTPS support, you'll need to create a configuration module.
 
 In our case, you could, e.g., create a file called `ssl.js` in the `ssl` folder with the following contents:
 

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -50,7 +50,7 @@ openssl req -x509 -nodes -out ssl/localhost.crt \
    printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 ```
 
-This has been adapted from <https://stackoverflow.com/a/56074120> according to the [`Let's encrypt` instructions](https://letsencrypt.org/docs/certificates-for-localhost/); additionally DigitalOcean provices some further explanations in [a tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04).
+This has been adapted from <https://stackoverflow.com/a/56074120> according to the [`Let's encrypt` instructions](https://letsencrypt.org/docs/certificates-for-localhost/); additionally, DigitalOcean provides some further explanations in [a tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04).
 
 #### Add the certificate to the trusted certificates
 

--- a/packages/docs/src/docs/running-patternlab.md
+++ b/packages/docs/src/docs/running-patternlab.md
@@ -60,7 +60,7 @@ A [stack overflow entry](https://stackoverflow.com/a/56074120) as well mentions 
 sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" "ssl/localhost.crt"
 ```
 
-You could as well skip this step and accept the certificate after opening the secured patternlab in your browser for the first time, as described in step 5 of the [DigitalOcean tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04#step-5-test-encryption).
+You could as well skip this step and accept the certificate after opening the secured pattern lab in your browser for the first time, as described in step 5 of the [DigitalOcean tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04#step-5-test-encryption).
 
 #### Configure the certificates for `live-server`
 


### PR DESCRIPTION
Closes #1291

Summary of changes:
Added documentation on how to setup HTTPS for the localhost / `live-server` dev server.