### PR TITLE
refactor: optimized engines directory retrieval

### DIFF
--- a/packages/core/src/lib/pattern_engines.js
+++ b/packages/core/src/lib/pattern_engines.js
@@ -9,14 +9,16 @@ const engineMatcher = /^engine-(.*)$/;
 
 const logger = require('./log');
 
+const { resolvePackageFolder } = require('@pattern-lab/core/src/lib/resolver');
+
 const enginesDirectories = [
   {
     displayName: 'the core',
     path: path.resolve(__dirname, '..', '..', 'node_modules'),
   },
   {
-    displayName: 'the edition or test directory',
-    path: path.join(process.cwd(), 'node_modules'),
+    displayName: 'the general node_modules directory',
+    path: path.resolve(resolvePackageFolder('@pattern-lab/core'), '..', '..'),
   },
 ];
 

--- a/packages/core/src/lib/pattern_engines.js
+++ b/packages/core/src/lib/pattern_engines.js
@@ -89,7 +89,9 @@ const PatternEngines = Object.create({
         engineDirectory.path
       );
 
-      logger.debug(`Loading engines from ${engineDirectory.displayName}...`);
+      logger.debug(
+        `Loading engines from ${engineDirectory.displayName}: ${engineDirectory.path} ...`
+      );
 
       // find all engine-named things in this directory and try to load them,
       // unless it's already been loaded.


### PR DESCRIPTION
Closes #1347

### Summary of changes:
The logic for resolving the path to engines directories has been implemented long before `npm workspaces` got introduced (actually with commit 416132c in mid 2016), so we would need to refactor this implementation.