### PR TITLE
refactor: clearing floats in a modern way

### DIFF
--- a/packages/uikit-workshop/src/sass/pattern-lab.scss
+++ b/packages/uikit-workshop/src/sass/pattern-lab.scss
@@ -105,11 +105,19 @@
 }
 
 .pl-c-main {
-  overflow-x: hidden;
+  // Preventing cropping pattern parts #1174 - absolutely positioned pattern parts at the vertical end of the "page" would get cropped elsewhere
   min-height: 100vh;
+
   max-width: 100vw;
   padding-left: .5rem;
   padding-right: .5rem;
+
+  // Clearing all remaining floats
+  &::after {
+    clear: both;
+    content: "";
+    display: table;
+  }
 }
 
 /*------------------------------------*\


### PR DESCRIPTION
The previous solution with overflow(-x) leads to several problems, previously regarding `overflow` on absolutely positioned elements being cropped, and now elements that are positioned `sticky` wouldn't work because of the `overflow-x` declaration.

Closes #1361

### Summary of changes:
As we don't want to actually control any overflow here, but mainly clear the remaining defined floats by the components, it might be much better to switch to an actual `clearfix`.