### PR TITLE
fix(core): Subgroup cannot be hidden

### DIFF
--- a/packages/core/src/lib/ui_builder.js
+++ b/packages/core/src/lib/ui_builder.js
@@ -102,7 +102,7 @@ const ui_builder = function () {
     // this pattern is contained with a directory documented as hidden (a handy way to hide whole directories from the nav
     isOmitted =
       (pattern.patternGroupData && pattern.patternGroupData.hidden) ||
-      (pattern.patternSubGroupData && pattern.patternSubGroupData.hidden) ||
+      (pattern.patternSubgroupData && pattern.patternSubgroupData.hidden) ||
       // TODO: Remove next two lines when removing support & deprecation waring for underscore prefix hiding
       pattern.relPath.charAt(0) === '_' ||
       pattern.relPath.indexOf(path.sep + '_') > -1;

--- a/packages/core/test/ui_builder_tests.js
+++ b/packages/core/test/ui_builder_tests.js
@@ -145,7 +145,7 @@ tap.test(
       patternPartial: 'shown-foo',
     });
 
-    pattern.patternSubGroupData = {
+    pattern.patternSubgroupData = {
       hidden: true,
     };
 


### PR DESCRIPTION
Closes #1366

### Summary of changes:

In the past, when I refactored the subgroup namings, I did miss those parameters. It is so trivial and took some time to find.
