### PR TITLE
fix(docs): tiles z-index to not overlay the menu anymore

### DIFF
--- a/packages/docs/src/scss/components/_tile.scss
+++ b/packages/docs/src/scss/components/_tile.scss
@@ -4,7 +4,6 @@
 
 .c-tile {
 	position: relative;
-	z-index: 100;
 	height: 100%;
 	display: flex;
 	flex-direction: column;

--- a/packages/docs/src/scss/components/_tile.scss
+++ b/packages/docs/src/scss/components/_tile.scss
@@ -12,7 +12,7 @@
 .c-tile__body {
 	padding: 2rem;
 	position: relative;
-	z-index: 1;
+	z-index: 1; // TODO: Evaluate whether this declaration is (still) necessary
 	flex: 1;
 
 	.c-tile--green & {
@@ -37,7 +37,7 @@
 	position: absolute;
 	right: -10px;
 	bottom: -10px;
-	z-index: 0;
+	z-index: 0; // TODO: Evaluate whether this declaration is (still) necessary
 	@include stripedBoxShadow('green');
 
 	.c-tile--orange & {


### PR DESCRIPTION
Closes #1170

### Summary of changes:
There has been a `z-index` defined that lead to the tiles overlaying the expanded menu entries. This one has been removed.