### PR TITLE
feat(vs-code): added recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ pattern_exports/
 .DS_Store
 Thumbs.db
 .nyc_output/
-.vscode/
 .idea/
 .env
 packages/core/test/public

--- a/.vscode/extensions.adoc
+++ b/.vscode/extensions.adoc
@@ -1,0 +1,10 @@
+= Extensions configuration
+
+See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+List of extensions which should be recommended for users of this workspace:
+`"recommendations"``
+
+List of extensions recommended by VS Code that should not be recommended for users of this workspace:
+`"unwantedRecommendations"``

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig", "henrynguyen5-vsc.vsc-nvm"]
+}


### PR DESCRIPTION
### Summary of changes:
As we're using both `.editorconfig` (Editorconfig for code styles definition) and `.nvmrc` (node version to use provided by Node Version Manager) it would be nice to have related Visual Studio Code plugins suggested to the users, so I've added those.