### PR TITLE
feat: define initial viewport

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -47,6 +47,12 @@ Sets whether or not you want the styleguide to load with the pattern info open o
 
 **default**: `false`
 
+## defaultInitialViewportWidth (optional)
+
+Possibility to define whether the initial viewport width on opening pattern lab in the browser should take the default of `100%` (value `true`) or take the (permanently) persisted value after the users have interacted with the viewport resize buttons previously (value `false`). This is especially beneficial in case that you'd expect the pages in full viewport at revisits, and even further if your startpage is defined as a "static" markdown welcome / orientation page.
+
+**default**: `false`
+
 ## defaultPatternInfoPanelCode (optional)
 
 Sets default active pattern info code panel by file extension - if unset, uses the value out of _patternExtension_ config value, or instead use value `html` to display the html code initially, or the value defined for the _patternExtension_.

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
@@ -397,6 +397,7 @@ class IFrame extends BaseLitComponent {
     const url = urlHandler.getFileName(this.getPatternParam());
 
     const initialWidth =
+      !window.config.defaultInitialViewportWidth &&
       store.getState().app.viewportPx &&
       store.getState().app.viewportPx <= this.clientWidth
         ? store.getState().app.viewportPx + 'px;'


### PR DESCRIPTION
Closes #1385

### Summary of changes:
Added the configuration option to deactivate resizing of the viewport according to the persisted viewport decisions the users have made previously. In the future we might even allow values in here instead of just a boolean.

I've decided to not prevent the persistence both for backwards compatibility as well as providing the possibility for a temporary or subpath specific setting, where we might not want to influence the persistence itself.