### PR TITLE
fix: corrected some github urls

### DIFF
--- a/packages/edition-node-gulp/README.md
+++ b/packages/edition-node-gulp/README.md
@@ -14,8 +14,8 @@ The Gulp wrapper around [Pattern Lab Node Core](https://github.com/pattern-lab/p
 This Edition comes with the following components:
 
 * `@pattern-lab/core`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/core) | [npm](https://www.npmjs.com/package/@pattern-lab/core)
-* `@pattern-lab/engine-mustache`: [GitHub](https://github.com/pattern-lab/tree/master/packages/engine-mustache) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-mustache)
-* `@pattern-lab/uikit-workshop`: [GitHub](https://github.com/pattern-lab/tree/master/packages/uikit-workshop) | [npm](https://www.npmjs.com/package/@pattern-lab/uikit-workshop)
+* `@pattern-lab/engine-mustache`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/engine-mustache) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-mustache)
+* `@pattern-lab/uikit-workshop`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/uikit-workshop) | [npm](https://www.npmjs.com/package/@pattern-lab/uikit-workshop)
 
 ## Prerequisites
 

--- a/packages/edition-node/README.md
+++ b/packages/edition-node/README.md
@@ -14,9 +14,9 @@ The pure wrapper around [Pattern Lab Node Core](https://github.com/pattern-lab/p
 This Edition comes with the following components:
 
 * `@pattern-lab/core`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/core) | [npm](https://www.npmjs.com/package/@pattern-lab/core)
-* `@pattern-lab/cli`: [GitHub](https://github.com/pattern-lab/tree/master/packages/cli) | [npm](https://www.npmjs.com/package/@pattern-lab/cli)
-* `@pattern-lab/engine-handlebars`: [GitHub](https://github.com/pattern-lab/tree/master/packages/engine-handlebars) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-handlebars)
-* `@pattern-lab/uikit-workshop`: [GitHub](https://github.com/pattern-lab/tree/master/packages/uikit-workshop) | [npm](https://www.npmjs.com/package/@pattern-lab/uikit-workshop)
+* `@pattern-lab/cli`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/cli) | [npm](https://www.npmjs.com/package/@pattern-lab/cli)
+* `@pattern-lab/engine-handlebars`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/engine-handlebars) | [npm](https://www.npmjs.com/package/@pattern-lab/engine-handlebars)
+* `@pattern-lab/uikit-workshop`: [GitHub](https://github.com/pattern-lab/patternlab-node/tree/master/packages/uikit-workshop) | [npm](https://www.npmjs.com/package/@pattern-lab/uikit-workshop)
 
 ## Prerequisites
 


### PR DESCRIPTION
### Summary of changes:
There were some URLs still pointing to the old Github repo structure, that needed to get corrected.
