### PR TITLE
chore(create): corrected default value

### DIFF
--- a/packages/cli/bin/inquiries/starterkit.js
+++ b/packages/cli/bin/inquiries/starterkit.js
@@ -34,7 +34,7 @@ const starterkitSetup = [
     ],
     default: {
       name: 'Handlebars demo patterns (full demo website and patterns)',
-      value: 'starterkit-handlebars-demo',
+      value: '@pattern-lab/starterkit-handlebars-demo',
     },
   },
   {


### PR DESCRIPTION
### Summary of changes:
Corrected the default value for `npm create pattern-lab`, as this field doesn't seem to have been updated to the new package names.