### PR TITLE
docs: aligning and describing our Node support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We only support actively [maintained](https://github.com/nodejs/Release#release-
 
 We specifically limit our support to maintenance versions of Node, not because this package won't work on other versions, but because we have a limited amount of time, and supporting the oldest maintenance offers the greatest return on that investment while still providing the lowest standard level for installations on any possible actively maintained environment out there.	 
 
-It's possible this package will work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node, though that's more unlikely as we'll make every effort to take advantage of features available in the oldest maintenance Node version we support.
+This package may work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node. However, that's more unlikely as we'll make every effort to take advantage of features available in the oldest maintenance Node version we support.
 
 As each Node maintenance version reaches its end-of-life we will replace that version from the `node` `engines` property of our package's `package.json` file with the newer oldes one. As this replacement would be considered a breaking change, we will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ Pattern Lab / Node wouldn't be what it is today without the support of the commu
 
 Thanks to [Netlify](https://www.netlify.com/) for build tooling and hosting.
 
+## Node Support Policy
+
+We only support actively [maintained](https://github.com/nodejs/Release#release-schedule) versions of Node.
+
+We specifically limit our support to maintenance versions of Node, not because this package won't work on other versions, but because we have a limited amount of time, and supporting the oldest maintenance offers the greatest return on that investment, while still providing the lowest common level for installations on any possible actively maintained environment out there.
+
+It's possible this package will work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node, though that's more unlikely as we'll make every effort to take advantage of features available in the oldest maintenance Node version we support.
+
+As each Node maintenance version reaches its end-of-life we will replace that version from the `node` `engines` property of our package's `package.json` file with the newer oldes one. As this replacement would be considered a breaking change, we will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
+
+And we might even update the minor and patch version of that supported maintenance Node version on a regular basis, without making this a breaking change than as it should be in everybodys interest to even also follow this concept of using patched software as their development system basis, especially on those older Node versions.
+
+We will accept code that allows this package to run on newer, non-maintenance, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, we even test that out by ourselves and get feedback from the community on a regular basis regarding all LTS versions of Node in addition the most recent Node release called current.
+
+JavaScript package managers like e.g. [NVM](https://github.com/nvm-sh/nvm) should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our `node` `engines` property. If you encounter issues installing this package, please report the issue to your package manager.
+
+This policy as been adapted from <https://github.com/conventional-changelog/conventional-changelog#node-support-policy>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We specifically limit our support to maintenance versions of Node, not because t
 
 This package may work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node. However, that's more unlikely as we'll make every effort to take advantage of features available in the oldest maintenance Node version we support.
 
-As each Node maintenance version reaches its end-of-life we will replace that version from the `node` `engines` property of our package's `package.json` file with the newer oldes one. As this replacement would be considered a breaking change, we will entail the publishing of a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
+As each Node maintenance version reaches its end-of-life, we will replace that version from the `node` `engines` property of our package's `package.json` file with the newer oldest one. As this replacement would be considered a breaking change, we will publish a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
 
 And we might even update the minor and patch version of that supported maintenance Node version on a regular basis, without making this a breaking change than as it should be in everybodys interest to even also follow this concept of using patched software as their development system basis, especially on those older Node versions.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ As each Node maintenance version reaches its end-of-life, we will replace that v
 
 And we might even update the minor and patch version of that supported maintenance Node version on a regular basis, without making this a breaking change than as it should be in everybodys interest to even also follow this concept of using patched software as their development system basis, especially on those older Node versions.
 
-We will accept code that allows this package to run on newer, non-maintenance, versions of Node. Furthermore, we will attempt to ensure our own changes work on the latest version of Node. To help in that commitment, we even test that out by ourselves and get feedback from the community on a regular basis regarding all LTS versions of Node in addition the most recent Node release called current.
+We will accept code that allows this package to run on newer, non-maintenance versions of Node. Furthermore, we will attempt to ensure our changes work on the latest version of Node. To help in that commitment, we even test that out by ourselves and get feedback from the community regularly regarding all LTS versions of Node and the most recent Node release called current.
 
 JavaScript package managers like e.g. [NVM](https://github.com/nvm-sh/nvm) should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our `node` `engines` property. If you encounter issues installing this package, please report the issue to your package manager.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This package may work correctly on newer versions of Node. It may even be possib
 
 As each Node maintenance version reaches its end-of-life, we will replace that version from the `node` `engines` property of our package's `package.json` file with the newer oldest one. As this replacement would be considered a breaking change, we will publish a new major version of this package. We will not accept any requests to support an end-of-life version of Node. Any merge requests or issues supporting an end-of-life version of Node will be closed.
 
-And we might even update the minor and patch version of that supported maintenance Node version on a regular basis, without making this a breaking change than as it should be in everybodys interest to even also follow this concept of using patched software as their development system basis, especially on those older Node versions.
+And we might even update the minor and patch version of that supported maintenance Node version regularly, without making this a breaking change than as it should be in everybody's interest even also to follow this concept of using patched software as their development system basis, especially on those older Node versions.
 
 We will accept code that allows this package to run on newer, non-maintenance versions of Node. Furthermore, we will attempt to ensure our changes work on the latest version of Node. To help in that commitment, we even test that out by ourselves and get feedback from the community regularly regarding all LTS versions of Node and the most recent Node release called current.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Thanks to [Netlify](https://www.netlify.com/) for build tooling and hosting.
 
 We only support actively [maintained](https://github.com/nodejs/Release#release-schedule) versions of Node.
 
-We specifically limit our support to maintenance versions of Node, not because this package won't work on other versions, but because we have a limited amount of time, and supporting the oldest maintenance offers the greatest return on that investment, while still providing the lowest common level for installations on any possible actively maintained environment out there.
+We specifically limit our support to maintenance versions of Node, not because this package won't work on other versions, but because we have a limited amount of time, and supporting the oldest maintenance offers the greatest return on that investment while still providing the lowest standard level for installations on any possible actively maintained environment out there.	 
 
 It's possible this package will work correctly on newer versions of Node. It may even be possible to use this package on older versions of Node, though that's more unlikely as we'll make every effort to take advantage of features available in the oldest maintenance Node version we support.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We will accept code that allows this package to run on newer, non-maintenance ve
 
 JavaScript package managers like e.g. [NVM](https://github.com/nvm-sh/nvm) should allow you to install this package with any version of Node, with, at most, a warning if your version of Node does not fall within the range specified by our `node` `engines` property. If you encounter issues installing this package, please report the issue to your package manager.
 
-This policy as been adapted from <https://github.com/conventional-changelog/conventional-changelog#node-support-policy>
+This policy has been adapted from <https://github.com/conventional-changelog/conventional-changelog#node-support-policy>.
 
 ## Contributing
 


### PR DESCRIPTION
### Summary of changes:
As our currently used [major Node version 12 reaches its end of life on 30th of April](https://github.com/nodejs/Release#release-schedule) it might be important to set up a common understanding and communicate on how we would like to handle Node Major version updates, and especially on whether we always switch to either LTS or the oldest supported maintenance version. I would argue for the latter, as this would ensure the most "common ground" setups out there (especially that everybody on lower Node versions should update in their own best interests, regarding security, etc.).

The policy included has been adapted from the one by the conventional changelog project: https://github.com/conventional-changelog/conventional-changelog#node-support-policy