### PR TITLE
fix(annotations): hiding those correctly

### DIFF
--- a/packages/starterkit-handlebars-demo/dist/css/pattern-scaffolding.css
+++ b/packages/starterkit-handlebars-demo/dist/css/pattern-scaffolding.css
@@ -299,7 +299,6 @@
  *    annotation attached to it.
  */
 .pl-c-annotation-tip {
-  display: flex;
   align-items: center;
   justify-content: center;
   width: 24px !important;
@@ -313,8 +312,8 @@
   position: absolute;
   z-index: 100;
 }
-.pl-c-annotation-tip[hidden] {
-  visibility: hidden;
+.pl-c-annotation-tip:not([hidden]) {
+  display: flex;
 }
 
 /*# sourceMappingURL=pattern-scaffolding.css.map */

--- a/packages/starterkit-handlebars-demo/dist/css/pattern-scaffolding.css
+++ b/packages/starterkit-handlebars-demo/dist/css/pattern-scaffolding.css
@@ -313,5 +313,8 @@
   position: absolute;
   z-index: 100;
 }
+.pl-c-annotation-tip[hidden] {
+  visibility: hidden;
+}
 
 /*# sourceMappingURL=pattern-scaffolding.css.map */

--- a/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
@@ -39,9 +39,7 @@
  *    annotation attached to it.
  */
 .pl-c-annotation-tip {
-  &:not([hidden]) {
-    display: flex;
-  }
+  display: flex;
   align-items: center;
   justify-content: center;
   width: 24px !important;
@@ -54,4 +52,8 @@
   font-size: 16px !important;
   position: absolute;
   z-index: 100;
+
+  &[hidden] {
+    visibility: hidden;
+  }
 }

--- a/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
@@ -39,7 +39,9 @@
  *    annotation attached to it.
  */
 .pl-c-annotation-tip {
-  display: flex;
+  &:not([hidden]) {
+    display: flex;
+  }
   align-items: center;
   justify-content: center;
   width: 24px !important;

--- a/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
+++ b/packages/uikit-workshop/src/sass/scss/04-components/_annotations.scss
@@ -39,7 +39,9 @@
  *    annotation attached to it.
  */
 .pl-c-annotation-tip {
-  display: flex;
+  &:not([hidden]) {
+    display: flex;
+  }
   align-items: center;
   justify-content: center;
   width: 24px !important;
@@ -52,8 +54,4 @@
   font-size: 16px !important;
   position: absolute;
   z-index: 100;
-
-  &[hidden] {
-    visibility: hidden;
-  }
 }


### PR DESCRIPTION
Resulting out of the latest changes by #1402 and #1406, the annotation tooltips haven't been hidden correctly.

### Summary of changes:
The annotations haven't been hidden correctly previously due to missing CSS after collapsing the panel again.

Preview URL: https://deploy-preview-1415--patternlab-handlebars-preview.netlify.app/?p=pages-homepage