### PR TITLE
refactor: updated node-fetch dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",
     "markdown-it": "12.0.6",
-    "node-fetch": "2.6.1",
+    "node-fetch": "2.6.7",
     "recursive-copy": "2.0.13",
     "update-notifier": "5.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11270,6 +11270,13 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"


### PR DESCRIPTION
Closes #1419

### Summary of changes:
Updated related [`node-fetch` dependency](https://www.npmjs.com/package/node-fetch) to the [newest security release](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7).

https://github.com/node-fetch/node-fetch/compare/v2.6.1...v2.6.7