### PR TITLE
feat: remove sandbox attribute from iframe

### DIFF
--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
@@ -413,7 +413,6 @@ class IFrame extends BaseLitComponent {
           <iframe
             class="pl-c-viewport__iframe pl-js-iframe pl-c-body--theme-${this
               .themeMode}"
-            sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals"
             src=${ifDefined(url === '' ? undefined : url)}
             srcdoc=${ifDefined(url === '' ? this.iframe404Fallback : undefined)}
             title="Pattern details"


### PR DESCRIPTION
Closes #1414

Summary of changes:
This removes the sandbox attribute from the iframe. 
As @mfranzke pointed out: Based on the following statement, the attribute is kind of pseudo security

> When the embedded document has the same origin as the embedding page, it is strongly discouraged to use both allow-scripts and allow-same-origin, as that lets the embedded document remove the sandbox attribute — making it no more secure than not using the sandbox attribute at all.

