### PR TITLE
refactor: updated markdown-it dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "js-beautify": "1.13.5",
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",
-    "markdown-it": "12.0.6",
+    "markdown-it": "12.3.2",
     "node-fetch": "2.6.7",
     "recursive-copy": "2.0.13",
     "update-notifier": "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10574,10 +10574,10 @@ markdown-it-anchor@^5.2.7:
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
   integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
 
-markdown-it@12.0.6:
-  version "12.0.6"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.6.tgz#adcc8e5fe020af292ccbdf161fe84f1961516138"
-  integrity sha512-qv3sVLl4lMT96LLtR7xeRJX11OUFjsaD5oVat2/SNBIb21bJXwal2+SklcRbTwGwqWpWH/HRtYavOoJE+seL8w==
+markdown-it@12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
   dependencies:
     argparse "^2.0.1"
     entities "~2.1.0"


### PR DESCRIPTION
Closes #1423

### Summary of changes:
Updated related [`markdown-it` dependency](https://www.npmjs.com/package/markdown-it) to the [newest (security) release](https://github.com/markdown-it/markdown-it/compare/12.3.1...12.3.2).

Changelog: https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md#1232---2022-01-08