### PR TITLE
fix: transformed asset types is ignored

### DIFF
--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -55,12 +55,12 @@ const copier = () => {
       debug: patternlab.config.logLevel === 'debug',
     };
 
-    // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from packages/core/src/lib/watchAssets.js#L45
+    // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from https://stackoverflow.com/a/18086622
     if (patternlab.config.transformedAssetTypes) {
       copyOptions.filter = new RegExp(
-        `^.*\\.(?!${patternlab.config.transformedAssetTypes.join(
-          '$|'
-        )}$)[^.]+$`,
+        `^(.*\.(?!(${patternlab.config.transformedAssetTypes.join(
+          '|'
+        )})$))?[^.]*$`,
         'i'
       );
     }

--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -49,11 +49,21 @@ const copier = () => {
     //find out where we are
     const basePath = path.resolve(process.cwd());
 
-    const copyOptions = {
+    let copyOptions = {
       overwrite: true,
       emitter: patternlab.events,
       debug: patternlab.config.logLevel === 'debug',
     };
+
+    // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from packages/core/src/lib/watchAssets.js#L45
+    if (patternlab.config.transformedAssetTypes) {
+      copyOptions.filter = new RegExp(
+        `^.*\\.(?!${patternlab.config.transformedAssetTypes.join(
+          '$|'
+        )}$)[^.]+$`,
+        'i'
+      );
+    }
 
     //loop through each directory asset object (source / public pairing)
 

--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -58,7 +58,7 @@ const copier = () => {
     // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from https://stackoverflow.com/a/6745455
     if (patternlab.config.transformedAssetTypes) {
       copyOptions.filter = new RegExp(
-        `.*(?<!\.${patternlab.config.transformedAssetTypes.join('|')})$`,
+        `.*(?<![.](${patternlab.config.transformedAssetTypes.join('|')}))$`,
         'i'
       );
     }

--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -49,7 +49,7 @@ const copier = () => {
     //find out where we are
     const basePath = path.resolve(process.cwd());
 
-    let copyOptions = {
+    const copyOptions = {
       overwrite: true,
       emitter: patternlab.events,
       debug: patternlab.config.logLevel === 'debug',

--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -55,12 +55,10 @@ const copier = () => {
       debug: patternlab.config.logLevel === 'debug',
     };
 
-    // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from https://stackoverflow.com/a/18086622
+    // Adding assets to filter for in case of transformedAssetTypes defined; adapted regex from https://stackoverflow.com/a/6745455
     if (patternlab.config.transformedAssetTypes) {
       copyOptions.filter = new RegExp(
-        `^(.*\.(?!(${patternlab.config.transformedAssetTypes.join(
-          '|'
-        )})$))?[^.]*$`,
+        `.*(?<!\.${patternlab.config.transformedAssetTypes.join('|')})$`,
         'i'
       );
     }

--- a/packages/core/src/lib/copier.js
+++ b/packages/core/src/lib/copier.js
@@ -102,7 +102,7 @@ const copier = () => {
     copyPromises.push(
       _.map(patternlab.uikits, (uikit) => {
         copyFile(
-          `${assetDirectories.source.root}/favicon.ico`,
+          `${assetDirectories.source.root}favicon.ico`,
           path.join(
             basePath,
             uikit.outputDir,


### PR DESCRIPTION
Closes #1339

### Summary of changes:
Added regex for filtering on allowed files to copy on `build` script for the underlaying [`recursive-copy` package by the `options.filter` option](https://www.npmjs.com/package/recursive-copy#user-content-usage). Using the same configuration of "transformed asset types", that are even also already defining the file types that should be watched during `serve` script.