### PR TITLE
refactor: make removing index.html from URL configurable

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -113,6 +113,14 @@ This replaces the now obsolete `debug` flag.
 
 **default**: `info`
 
+## noIndexHtmlremoval (optional)
+
+You might host your pattern lab in an environment that doesn't acknowledge the default file to be `index.html` in case that none is provided – Gitlab Pages is an example for this, where you might publish your preview builds to during development. So in case that you get a URL like `<PATH>/index.html`, it will redirect to `<PATH>/?p=all`. You might not be able to share this resulting URL or even do a refresh of the page, as the server would respond with a 404 error.
+
+To disable this redirect which is similar to how Single Page Applications work, you could set the optional configuration `"noIndexHtmlremoval"` to `true`.
+
+**default**: `false`
+
 ## outputFileSuffixes
 
 Sets the naming of output pattern files. Suffixes are defined for 'rendered', 'rawTemplate', and 'markupOnly' files. This configuration is needed for some PatternEngines that use the same input and output file extensions. Most users will not have to change this.

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-viewport/pl-viewport.js
@@ -152,7 +152,9 @@ class IFrame extends BaseLitComponent {
           : window.location.protocol +
             '//' +
             window.location.host +
-            window.location.pathname.replace('index.html', '') +
+            (window.config.noIndexHtmlremoval
+              ? window.location.pathname
+              : window.location.pathname.replace('index.html', '')) +
             '?p=' +
             currentPattern;
 
@@ -512,7 +514,9 @@ class IFrame extends BaseLitComponent {
             : window.location.protocol +
               '//' +
               window.location.host +
-              window.location.pathname.replace('index.html', '') +
+              (window.config.noIndexHtmlremoval
+                ? window.location.pathname
+                : window.location.pathname.replace('index.html', '')) +
               '?p=' +
               currentPattern;
 


### PR DESCRIPTION
Closes #1427

### Summary of changes:
I've decided to make this change configurable, especially for backwards "compatibility" (or in other words not changing the current behavior).
Providing the possibility to deactivate the initial redirect and changing of the history towards the removal of an included `index.html` within the URL: from `/index.html?p=WHATEVER` to `/?p=WHATEVER`, as this might cause trouble on environments that don't acknowledge an `index.html` file if no file is provided in the URL.

Even though that this is a suboptimal configuration, under some circumstances you're able to change it (like on a public static hosting provider).