### PR TITLE
fix: twig logo is rendered as "NaN"

### DIFF
--- a/packages/starterkit-twig-demo/dist/_patterns/atoms/images/logo.twig
+++ b/packages/starterkit-twig-demo/dist/_patterns/atoms/images/logo.twig
@@ -1,1 +1,1 @@
-<a href="{{ link.pages-homepage }}"><img src="../../images/logo.png" width="350" height="100" class="logo" alt="Logo Alt Text" /></a>
+<a href="{{ link['pages-homepage'] }}"><img src="../../images/logo.png" width="350" height="100" class="logo" alt="Logo Alt Text" /></a>


### PR DESCRIPTION
Closes: #1407

Summary of changes:

- fix access for links in twig with hyphen in array key
