### PR TITLE
chore: using current node version in CI/CD as well

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v2.1.4
         with:
-          node-version: '>=14.20.1'
+          node-version: '<15'
 
       - name: Setup the project
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v2.1.4
+        uses: actions/setup-node@v2
         with:
           node-version: '<15'
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: '<15'
+          node-version: '14'
 
       - name: Setup the project
         run: |


### PR DESCRIPTION
### Summary of changes:
Currently we would be using some Node version 18 within our GitHub CI/CD pipeline, but it would be better to even also stick to the current Node version [we're supporting for our package](https://github.com/pattern-lab/patternlab-node/blob/dev/README.md#node-support-policy). And not pin `actions/setup-node` to a specific version underneath a major version to prevent necessary manual updates.