### PR TITLE
fix: hogan to handlebars migration leftovers

### DIFF
--- a/packages/uikit-workshop/src/scripts/components/panels-viewer.js
+++ b/packages/uikit-workshop/src/scripts/components/panels-viewer.js
@@ -3,7 +3,7 @@
  */
 /* eslint-disable no-param-reassign, no-unused-vars */
 
-import Handlebars from 'handlebars';
+import Handlebars from 'handlebars/dist/handlebars';
 import pretty from 'pretty';
 import { html, render } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
@@ -176,7 +176,7 @@ export const panelsViewer = {
           // vanilla render of pattern data
           template = document.getElementById(panel.templateID);
           templateCompiled = Handlebars.compile(template.innerHTML);
-          templateRendered = templateCompiled.render(patternData);
+          templateRendered = templateCompiled(patternData);
           const normalizedCode =
             normalizeWhitespace.normalize(templateRendered);
           normalizedCode.replace(/[\r\n]+/g, '\n\n');
@@ -305,7 +305,7 @@ export const panelsViewer = {
     // render all of the panels in the base panel template
     const template = document.querySelector('.pl-js-panel-template-base');
     const templateCompiled = Handlebars.compile(template.innerHTML);
-    templateRendered = templateCompiled.render(patternData);
+    templateRendered = templateCompiled(patternData);
 
     // make sure templateRendered is modified to be an HTML element
     const div = document.createElement('div');


### PR DESCRIPTION
Closes https://github.com/pattern-lab/patternlab-node/issues/1460

### Summary of changes:
As a leftover to the changes by https://github.com/pattern-lab/patternlab-node/pull/1456 I missed some parts regarding the correct dependency references path as well as the changed way of how to [`render` the template / data bindings](https://handlebarsjs.com/guide/#installation).