### PR TITLE
refactor: replaced hogan by handlebars

### DIFF
--- a/packages/engine-react/lib/engine_react.js
+++ b/packages/engine-react/lib/engine_react.js
@@ -14,7 +14,7 @@ const path = require('path');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
 const Babel = require('babel-core');
-const Hogan = require('hogan');
+const Handlebars = require('handlebars');
 const beautify = require('js-beautify');
 const cheerio = require('cheerio');
 const _require = require;
@@ -44,8 +44,8 @@ let patternLabConfig = {};
 
 let enableRuntimeCode = true;
 
-const outputTemplate = Hogan.compile(
-  fs.readFileSync(path.join(__dirname, './outputTemplate.mustache'), 'utf8')
+const outputTemplate = Handlebars.compile(
+  fs.readFileSync(path.join(__dirname, './outputTemplate.hbs'), 'utf8')
 );
 
 let registeredComponents = {
@@ -106,7 +106,7 @@ var engine_react = {
       React.createFactory(transpiledModule)(data)
     );
 
-    renderedHTML = outputTemplate.render({
+    renderedHTML = outputTemplate({
       htmlOutput: staticMarkup,
     });
 

--- a/packages/engine-react/lib/outputTemplate.hbs
+++ b/packages/engine-react/lib/outputTemplate.hbs
@@ -1,0 +1,1 @@
+{{{htmlOutput}}}

--- a/packages/engine-react/lib/outputTemplate.mustache
+++ b/packages/engine-react/lib/outputTemplate.mustache
@@ -1,1 +1,0 @@
-{{{htmlOutput}}}

--- a/packages/engine-react/package.json
+++ b/packages/engine-react/package.json
@@ -9,7 +9,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "6.16.0",
     "babel-preset-react": "6.16.0",
     "cheerio": "0.22.0",
-    "hogan": "1.0.2",
+    "handlebars": "4.7.7",
     "js-beautify": "1.13.5",
     "react": "15.3.2",
     "react-dom": "15.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7972,7 +7972,7 @@ hamljs@^0.6.2:
   resolved "https://registry.yarnpkg.com/hamljs/-/hamljs-0.6.2.tgz#7b7116cf6dbe7278e42b3f6ef8725a33e177c8e3"
   integrity sha1-e3EWz22+cnjkKz9u+HJaM+F3yOM=
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@4.7.7, handlebars@^4.7.6, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -8180,21 +8180,6 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hogan.js@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
-  integrity sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==
-  dependencies:
-    mkdirp "0.3.0"
-    nopt "1.0.10"
-
-hogan@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hogan/-/hogan-1.0.2.tgz#d8d5e57fae0e7787b3e01e14256f9d588a23d1f0"
-  integrity sha512-2RV7G4f+Rt9YIYDu01r6pgZvP+XhrXi/JKlXd4b+vRybXk94ui4PQjbh/lFaH8gQtxCygy/WKkqmpm0IyZysJA==
-  dependencies:
-    hogan.js "*"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -11072,11 +11057,6 @@ mkdirp2@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp2/-/mkdirp2-1.0.5.tgz#68bbe61defefafce4b48948608ec0bac942512c2"
   integrity sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==
 
-mkdirp@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
-  integrity sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==
-
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -11417,13 +11397,6 @@ noms@0.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "~1.0.31"
-
-nopt@1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
-  dependencies:
-    abbrev "1"
 
 nopt@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
### Summary of changes:
As a follow up to https://github.com/pattern-lab/patternlab-node/pull/1456 and in an effort to keep our codebase up to date, we're replacing the much older [hogan](https://www.npmjs.com/package/hogan) (last release eight years ago) by [handlebars](https://www.npmjs.com/package/handlebars) (that we're using anyhow within our codebase).

This should both reduce outdated subdependencies, as well as speed up running the system.