### PR TITLE
fix: js error

### DIFF
--- a/packages/uikit-workshop/src/scripts/components/pl-nav/nav.js
+++ b/packages/uikit-workshop/src/scripts/components/pl-nav/nav.js
@@ -108,7 +108,7 @@ class Nav extends BaseComponent {
 
   receiveIframeMessage(event) {
     const self = this;
-    const data = iframeMsgDataExtraction(e);
+    const data = iframeMsgDataExtraction(event);
 
     if (data.event !== undefined && data.event === 'patternLab.pageClick') {
       try {

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-header/pl-header.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-header/pl-header.js
@@ -149,10 +149,10 @@ class Header extends BaseLitComponent {
    *
    * @param {MessageEvent} e A message received by a target object.
    */
-  receiveIframeMessage(e) {
+  receiveIframeMessage(event) {
     const self = this;
 
-    const data = iframeMsgDataExtraction(e);
+    const data = iframeMsgDataExtraction(event);
 
     if (data.event !== undefined && data.event === 'patternLab.pageClick') {
       try {

--- a/packages/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
+++ b/packages/uikit-workshop/src/scripts/lit-components/pl-tools-menu/pl-tools-menu.js
@@ -103,10 +103,10 @@ class ToolsMenu extends BaseLitComponent {
    *
    * @param {MessageEvent} e A message received by a target object.
    */
-  receiveIframeMessage(e) {
+  receiveIframeMessage(event) {
     const self = this;
 
-    const data = iframeMsgDataExtraction(e);
+    const data = iframeMsgDataExtraction(event);
 
     if (data.event !== undefined && data.event === 'patternLab.pageClick') {
       try {


### PR DESCRIPTION
### Summary of changes:
There's a JS error due to the change at https://github.com/pattern-lab/patternlab-node/pull/1102/files#diff-9111c2e0138c935342632437be7178f25322b8f5c86431f2b85f4fe760d32980L96-R111 in which a method parameter has been renamed within the file `packages/uikit-workshop/src/scripts/components/pl-nav/nav.js`, but not within the method references itself.

Renamed the `e` parameter to `event` within two other files as well to align and clarify the naming.