### PR TITLE
fix(twig engine): startup and running problems

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "version": "6.0.0",
   "main": "./src/index.js",
   "dependencies": {
+    "@pattern-lab/engine-handlebars": "^6.0.0",
     "@pattern-lab/engine-mustache": "^6.0.0",
     "@pattern-lab/live-server": "^6.0.0",
     "chalk": "4.1.0",

--- a/packages/core/src/lib/get.js
+++ b/packages/core/src/lib/get.js
@@ -35,7 +35,7 @@ module.exports = function (partialName, patternlab, reportWarning = true) {
   }
   if (reportWarning) {
     logger.warning(
-      `Could not find pattern referenced with partial syntax ${partialName}.
+      `Could not find pattern referenced with partial syntax "${partialName}" from "${patternlab.config.paths.source.patterns}".
       This can occur when a pattern was renamed, moved, or no longer exists but it still referenced within a different template or within data as a link.`
     );
   }

--- a/packages/edition-twig/patternlab-config.json
+++ b/packages/edition-twig/patternlab-config.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "twig": {
+    "twig-php": {
       "package": "@pattern-lab/engine-twig-php",
       "fileExtensions": [
         "twig"

--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -40,13 +40,17 @@ const engine_twig_php = {
   usePatternLabConfig: function (config) {
     patternLabConfig = config;
 
-    if (!config.engines.twig) {
+    if (!config.engines['twig-php']) {
       console.error('Missing "twig" in Pattern Lab config file; exiting...');
       process.exit(1);
     }
 
     const { namespaces, alterTwigEnv, relativeFrom, ...rest } =
-      config.engines.twig;
+      config.engines['twig-php'];
+
+    // since package is a reserved word in node, we need to delete it from the config object like this
+    delete rest.package;
+    delete rest.fileExtensions;
 
     // Schema on config object being passed in:
     // https://github.com/basaltinc/twig-renderer/blob/master/config.schema.json
@@ -57,7 +61,6 @@ const engine_twig_php = {
       },
       relativeFrom,
       alterTwigEnv,
-      package,
       ...rest,
     });
 
@@ -222,10 +225,7 @@ const engine_twig_php = {
 
               // then tease out the folder name itself (including the # prefix)
               // ex. atoms
-              const folderName = fullFolderPath.substring(
-                fullFolderPath.lastIndexOf('/') + 1,
-                fullFolderPath.length
-              );
+              const folderName = path.parse(fullFolderPath).base;
 
               // finally, return the Twig path we created from the full file path
               // ex. atoms/buttons/button.twig

--- a/packages/engine-twig-php/lib/engine_twig_php.js
+++ b/packages/engine-twig-php/lib/engine_twig_php.js
@@ -57,6 +57,7 @@ const engine_twig_php = {
       },
       relativeFrom,
       alterTwigEnv,
+      package,
       ...rest,
     });
 

--- a/packages/starterkit-twig-demo/patternlab-config.json
+++ b/packages/starterkit-twig-demo/patternlab-config.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "twig": {
+    "twig-php": {
       "package": "@pattern-lab/engine-twig-php",
       "fileExtensions": [
         "twig"


### PR DESCRIPTION
Closes #1477

### Summary of changes:
Added a missing entry (`package`) to the schema of the twig renderer, which prevented to use a reworked config object (most likely a necessary followup to https://github.com/pattern-lab/patternlab-node/pull/1256, as this new field was introduced with this PR).