### PR TITLE
docs: corrected that entry in the specs

### DIFF
--- a/packages/docs/src/docs/advanced-config-options.md
+++ b/packages/docs/src/docs/advanced-config-options.md
@@ -198,7 +198,7 @@ Other engine specific configuration options can be added and will be passed to t
   "engines": {
     "handlebars": {
       "package": "@pattern-lab/engine-handlebars",
-      "extensions": [
+      "fileExtensions": [
         "handlebars",
         "hbs"
       ],


### PR DESCRIPTION
Closes #1480

### Summary of changes:
Corrected `extensions` to be `fileExtensions` in the documentation.