### PR TITLE
fix: subitems menu height restricted only for horizontal mode

### DIFF
--- a/packages/uikit-workshop/src/scripts/components/pl-nav/nav-accordion.scss
+++ b/packages/uikit-workshop/src/scripts/components/pl-nav/nav-accordion.scss
@@ -18,10 +18,9 @@
 
   .pl-c-body--theme-horizontal & {
     overflow: auto;
-  }
 
-  @media all and (min-width: $pl-bp-med) {
-    height: auto;
-    max-height: calc(100vh - #{$offset-top} - 2rem); /* 1 */
+    @media all and (min-width: $pl-bp-med) {
+      max-height: calc(100vh - #{$offset-top} - 2rem); /* 1 */
+    }
   }
 }


### PR DESCRIPTION
Closes #1491 

### Summary of changes:
This is related to a change out of https://github.com/pattern-lab/patternlab-node/pull/1102/files#diff-c6ea82df3775776f3aef432cf591cbc9ee94c10a98e9471ec4567d5ea51efe74R22-R26

As this one was most likely meant for horizontal nav display, in which it makes good sense, but wasn't restricted to this one, it's now letting longer items or lists of opened subitems getting cropped of or even disappear.